### PR TITLE
Fix errors in Codable introduced with Xcode 11.5 

### DIFF
--- a/Sources/JsonModel/Documentable.swift
+++ b/Sources/JsonModel/Documentable.swift
@@ -103,6 +103,33 @@ public protocol DocumentableObject : Documentable {
     static func jsonExamples() throws -> [[String : JsonSerializable]]
 }
 
+/// Structs that implement the Codable protocol.
+public protocol DocumentableStruct : DocumentableObject, Codable {
+    static func examples() -> [Self]
+}
+
+extension DocumentableStruct {
+    public static func isOpen() -> Bool {
+        return false
+    }
+    
+    public static func jsonExamples() throws -> [[String : JsonSerializable]] {
+        return try examples().map { try $0.jsonEncodedDictionary() }
+    }
+}
+
+public protocol DocumentableInterface : Documentable {
+    
+    /// The name of the interface that is described by this documentable.
+    var interfaceName : String { get }
+    
+    /// The description to use in documentation.
+    var documentDescription : String? { get }
+    
+    /// A list of `DocumentableObject` classes that implement this interface.
+    func documentableExamples() -> [DocumentableObject]
+}
+
 /// A light-weight wrapper
 public struct DocumentProperty {
 
@@ -147,20 +174,6 @@ public struct DocumentProperty {
     }
 }
 
-/// Structs that implement the Codable protocol.
-public protocol DocumentableStruct : DocumentableObject, Codable {
-    static func examples() -> [Self]
-}
-
-extension DocumentableStruct {
-    public static func isOpen() -> Bool {
-        return false
-    }
-    
-    public static func jsonExamples() throws -> [[String : JsonSerializable]] {
-        return try examples().map { try $0.jsonEncodedDictionary() }
-    }
-}
 
 /// Errors that can be thrown while building documentation.
 public enum DocumentableError : Error {

--- a/Sources/JsonModel/JsonElement.swift
+++ b/Sources/JsonModel/JsonElement.swift
@@ -86,7 +86,7 @@ public enum JsonElement : Codable, Hashable {
         else if let value = obj as? Bool {
             self = .boolean(value)
         }
-        else if obj is FixedWidthInteger, let value = obj as? NSNumber {
+        else if obj is IntegerNumber, let value = obj as? NSNumber {
             self = .integer(value.intValue)
         }
         else if let value = obj as? JsonNumber {
@@ -244,3 +244,31 @@ extension NumberFormatter : JsonElementFormatter {
         }
     }
 }
+
+protocol IntegerNumber {
+}
+
+extension Int : IntegerNumber {
+}
+
+extension Int16 : IntegerNumber {
+}
+
+extension Int32 : IntegerNumber {
+}
+
+extension Int64 : IntegerNumber {
+}
+
+extension UInt : IntegerNumber {
+}
+
+extension UInt16 : IntegerNumber {
+}
+
+extension UInt32 : IntegerNumber {
+}
+
+extension UInt64 : IntegerNumber {
+}
+

--- a/Sources/JsonModel/PolymorphicSerializer.swift
+++ b/Sources/JsonModel/PolymorphicSerializer.swift
@@ -54,7 +54,7 @@ public protocol PolymorphicRepresentable : Decodable {
 /// The generic method for a decodable. This is a work-around for the limitations of Swift generics
 /// where an instance of a class that has an associated type cannot be stored in a dictionary or
 /// array.
-public protocol GenericSerializer : class {
+public protocol GenericSerializer : class, DocumentableInterface {
     var interfaceName : String { get }
     func decode(from decoder: Decoder) throws -> Any
     func documentableExamples() -> [DocumentableObject]

--- a/Tests/JsonModelTests/JsonValueTests.swift
+++ b/Tests/JsonModelTests/JsonValueTests.swift
@@ -267,7 +267,12 @@ final class JsonValueTests: XCTestCase {
         
         let obj = Set([uuid1, uuid2, uuid3])
         let json = obj.jsonObject()
-        XCTAssertEqual((json as? [String])?.count, 3)
+        if let arr = json as? [JsonSerializable] {
+            XCTAssertEqual(arr.count, 3)
+        }
+        else {
+            XCTFail("\(json) not of expected cast.")
+        }
         XCTAssertTrue(JSONSerialization.isValidJSONObject(json))
     }
 }

--- a/Tests/JsonModelTests/PolymorphicSerializerTests.swift
+++ b/Tests/JsonModelTests/PolymorphicSerializerTests.swift
@@ -129,6 +129,10 @@ struct SampleWrapper : Codable {
 }
 
 class SampleSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
+    var documentDescription: String? {
+        "Sample is an example interface used for unit testing."
+    }
+    
     let examples: [Sample] = [
         SampleA(value: 3),
         SampleB(value: "foo"),


### PR DESCRIPTION
Discovered that the unit tests were breaking b/c of a change to the way encoders and decoders work with Xcode 11.5. Namely, you can no longer encode a top-level object that is *not* an array or object (json blob).

Note 1: I am not sure what bugs this will introduce with existing code, but this will fix for this package which should fix SageResearch for the latest build. I don't think we ever use a primitive for the "clientData" blob, but instead I think changed that a while ago to always encode an object or array, but I will check.

Note 2: This includes some stubbed out code that is for changes to the Json Schema documentable, but I did that before running tests and didn't really want to mess with cherry picking since it's not a substantial change to the code.