### PR TITLE
Move "Result" protocol into JsonModel

### DIFF
--- a/Sources/JsonModel/AnyCodingKey.swift
+++ b/Sources/JsonModel/AnyCodingKey.swift
@@ -227,25 +227,3 @@ extension Dictionary {
         return result
     }
 }
-
-extension Encodable {
-    
-    /// Return the `JsonElement` for this object using the serialization strategy for numbers and
-    /// dates defined by `SerializationFactory.defaultFactory`.
-    public func jsonElement(using factory: SerializationFactory = SerializationFactory.defaultFactory) throws -> JsonElement {
-        let arr = [self]
-        let data = try factory.createJSONEncoder().encode(arr)
-        let json = try factory.createJSONDecoder().decode([JsonElement].self, from: data)
-        return json.first!
-    }
-    
-    /// Return the dictionary representation for this object.
-    public func jsonEncodedDictionary(using factory: SerializationFactory = SerializationFactory.defaultFactory) throws -> [String : JsonSerializable] {
-        let json = try self.jsonElement(using: factory)
-        guard case .object(let dictionary) = json else {
-            let context = EncodingError.Context(codingPath: [], debugDescription: "Failed to encode the object into a dictionary.")
-            throw EncodingError.invalidValue(json, context)
-        }
-        return dictionary
-    }
-}

--- a/Sources/JsonModel/Encodable+Utilities.swift
+++ b/Sources/JsonModel/Encodable+Utilities.swift
@@ -1,0 +1,78 @@
+//
+//  Encodable+Utilies.swift
+//  
+//
+//  Copyright © 2017-2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+extension Encodable {
+    
+    /// Return the `JsonElement` for this object using the serialization strategy for numbers and
+    /// dates defined by `SerializationFactory.defaultFactory`.
+    public func jsonElement(using factory: SerializationFactory = SerializationFactory.defaultFactory) throws -> JsonElement {
+        let arr = [self]
+        let data = try factory.createJSONEncoder().encode(arr)
+        let json = try factory.createJSONDecoder().decode([JsonElement].self, from: data)
+        return json.first!
+    }
+    
+    /// Return the dictionary representation for this object.
+    public func jsonEncodedDictionary(using factory: SerializationFactory = SerializationFactory.defaultFactory) throws -> [String : JsonSerializable] {
+        let json = try self.jsonElement(using: factory)
+        guard case .object(let dictionary) = json else {
+            let context = EncodingError.Context(codingPath: [], debugDescription: "Failed to encode the object into a dictionary.")
+            throw EncodingError.invalidValue(json, context)
+        }
+        return dictionary
+    }
+    
+    /// Returns JSON-encoded data created by encoding this object using a JSON encoder created
+    /// by the shared `RSDFactory` singleton.
+    public func jsonEncodedData(using factory: SerializationFactory = SerializationFactory.defaultFactory) throws -> Data {
+        let jsonEncoder = factory.createJSONEncoder()
+        return try self.encodeObject(to: jsonEncoder)
+    }
+    
+    /// Encode the object using the factory encoder.
+    fileprivate func encodeObject(to encoder: FactoryEncoder) throws -> Data {
+        let wrapper = _EncodableWrapper(encodable: self)
+        return try encoder.encode(wrapper)
+    }
+}
+
+/// The wrapper is required b/c `JSONEncoder` does not implement the `Encoder` protocol.
+/// Instead, it uses a private wrapper to box the encoded object.
+fileprivate struct _EncodableWrapper: Encodable {
+    let encodable: Encodable
+    func encode(to encoder: Encoder) throws {
+        try encodable.encode(to: encoder)
+    }
+}

--- a/Sources/JsonModel/IdentifiableInterfaceSerializer.swift
+++ b/Sources/JsonModel/IdentifiableInterfaceSerializer.swift
@@ -1,0 +1,61 @@
+//
+//  IdentifiableInterfaceSerializer.swift
+//
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// Convenience implementation for a serializer that includes a required `identifier` key.
+open class IdentifiableInterfaceSerializer : AbstractPolymorphicSerializer {
+    private enum InterfaceKeys : String, CodingKey, CaseIterable {
+        case identifier
+    }
+    
+    open override class func codingKeys() -> [CodingKey] {
+        var keys = super.codingKeys()
+        keys.append(contentsOf: InterfaceKeys.allCases)
+        return keys
+    }
+    
+    open override class func isRequired(_ codingKey: CodingKey) -> Bool {
+        (codingKey is InterfaceKeys) || super.isRequired(codingKey)
+    }
+    
+    open override class func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
+        guard let key = codingKey as? InterfaceKeys else {
+            return try super.documentProperty(for: codingKey)
+        }
+        switch key {
+        case .identifier:
+            return .init(propertyType: .primitive(.string))
+        }
+    }
+}

--- a/Sources/JsonModel/JsonValue.swift
+++ b/Sources/JsonModel/JsonValue.swift
@@ -32,12 +32,14 @@
 
 import Foundation
 
-/// Protocol for converting an object to a dictionary representation. This is included for reverse-compatiblility to
-/// older implementations that are not Swift `Codable` and instead use a dictionary representation.
+/// Protocol for converting an object to a dictionary representation. This is included for
+/// reverse-compatiblility to older implementations that are not Swift `Codable` and instead
+/// use a dictionary representation. Additionally, this can be used to implement Kotlin-Native
+/// serializable objects that do not conform to the Codable protocol.
 public protocol DictionaryRepresentable {
     
     /// Return the dictionary representation for this object.
-    func dictionaryRepresentation() -> [String : JsonSerializable]
+    func jsonDictionary() throws -> [String : JsonSerializable]
 }
 
 /// Protocol for converting objects to JSON serializable objects.
@@ -274,8 +276,8 @@ fileprivate func _convertToJSONValue(from object: Any) -> JsonSerializable {
     if let obj = object as? JsonValue {
         return obj.jsonObject()
     }
-    else if let obj = object as? DictionaryRepresentable {
-        return obj.dictionaryRepresentation()
+    else if let obj = object as? DictionaryRepresentable, let json = try? obj.jsonDictionary() {
+        return json
     }
     else if let obj = object as? NSObjectProtocol {
         return obj.description

--- a/Sources/JsonModel/PolymorphicSerializer.swift
+++ b/Sources/JsonModel/PolymorphicSerializer.swift
@@ -47,7 +47,11 @@ import Foundation
 ///
 /// - seealso: `PolymorphicSerializerTests`
 ///
-public protocol PolymorphicRepresentable : Decodable {
+public protocol PolymorphicRepresentable : PolymorphicTyped, Decodable {
+}
+
+public protocol PolymorphicTyped {
+    /// A "name" for the class of object that can be used in Dictionary representable objects.
     var typeName: String { get }
 }
 

--- a/Sources/JsonModel/ResultData/CollectionResultObject.swift
+++ b/Sources/JsonModel/ResultData/CollectionResultObject.swift
@@ -1,0 +1,130 @@
+//
+//  CollectionResultObject.swift
+//  
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `CollectionResultObject` is used include multiple results associated with a single action.
+public final class CollectionResultObject : SerializableResultData {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case serializableResultType="type", identifier, startDate, endDate, children="inputResults"
+    }
+    public private(set) var serializableResultType: SerializableResultType = .collection
+    
+    public let identifier: String
+    public var startDate: Date
+    public var endDate: Date
+    
+    /// The list of input results associated with this step. These are generally assumed to be answers to
+    /// field inputs, but they are not required to implement the `RSDAnswerResult` protocol.
+    public var children: [ResultData]
+    
+    public init(identifier: String) {
+        self.identifier = identifier
+        self.startDate = Date()
+        self.endDate = Date()
+        self.children = []
+    }
+    
+    /// Initialize from a `Decoder`. This decoding method will use the `RSDFactory` instance associated
+    /// with the decoder to decode the `inputResults`.
+    ///
+    /// - parameter decoder: The decoder to use to decode this instance.
+    /// - throws: `DecodingError`
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.startDate = try container.decodeIfPresent(Date.self, forKey: .startDate) ?? Date()
+        self.endDate = try container.decodeIfPresent(Date.self, forKey: .endDate) ?? Date()
+        
+        let resultsContainer = try container.nestedUnkeyedContainer(forKey: .children)
+        self.children = try decoder.serializationFactory.decodePolymorphicArray(ResultData.self, from: resultsContainer)
+    }
+    
+    /// Encode the result to the given encoder.
+    /// - parameter encoder: The encoder to use to encode this instance.
+    /// - throws: `EncodingError`
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(serializableResultType, forKey: .serializableResultType)
+        try container.encode(identifier, forKey: .identifier)
+        try container.encode(startDate, forKey: .startDate)
+        try container.encode(endDate, forKey: .endDate)
+        
+        var nestedContainer = container.nestedUnkeyedContainer(forKey: .children)
+        try children.forEach { result in
+            let nestedEncoder = nestedContainer.superEncoder()
+            if let encodable = result as? Encodable {
+                try encodable.encode(to: nestedEncoder)
+            }
+            else {
+                let json = try result.jsonDictionary()
+                let element: JsonElement = .object(json)
+                try element.encode(to: nestedEncoder)
+            }
+        }
+    }
+}
+
+extension CollectionResultObject : DocumentableStruct {
+    public static func codingKeys() -> [CodingKey] {
+        return CodingKeys.allCases
+    }
+    
+    public static func isRequired(_ codingKey: CodingKey) -> Bool {
+        true
+    }
+    
+    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
+        guard let key = codingKey as? CodingKeys else {
+            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
+        }
+        switch key {
+        case .serializableResultType:
+            return .init(constValue: SerializableResultType.collection)
+        case .identifier:
+            return .init(propertyType: .primitive(.string))
+        case .startDate, .endDate:
+            return .init(propertyType: .format(.dateTime))
+        case .children:
+            return .init(propertyType: .interfaceArray("\(ResultData.self)"))
+        }
+    }
+    
+    public static func examples() -> [CollectionResultObject] {
+        let result = CollectionResultObject(identifier: "answers")
+        result.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
+        result.endDate = result.startDate.addingTimeInterval(5 * 60)
+        result.children = JsonElementResultObject.examples()
+        return [result]
+    }
+}

--- a/Sources/JsonModel/ResultData/CollectionResultObject.swift
+++ b/Sources/JsonModel/ResultData/CollectionResultObject.swift
@@ -33,7 +33,7 @@
 
 import Foundation
 
-/// `CollectionResultObject` is used include multiple results associated with a single action.
+/// `CollectionResultObject` is used to include multiple results associated with a single action.
 public final class CollectionResultObject : SerializableResultData {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableResultType="type", identifier, startDate, endDate, children="inputResults"

--- a/Sources/JsonModel/ResultData/ErrorResultObject.swift
+++ b/Sources/JsonModel/ResultData/ErrorResultObject.swift
@@ -1,0 +1,115 @@
+//
+//  ErrorResultObject.swift
+//  
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `ErrorResultObject` is a result that holds information about an error.
+public struct ErrorResultObject : SerializableResultData {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case serializableResultType="type", identifier, startDate, endDate, errorDescription, errorDomain, errorCode
+    }
+    public private(set) var serializableResultType: SerializableResultType = .error
+    
+    public let identifier: String
+    public var startDate: Date
+    public var endDate: Date
+    
+    /// A description associated with an `NSError`.
+    public let errorDescription: String
+    
+    /// A domain associated with an `NSError`.
+    public let errorDomain: String
+    
+    /// The error code associated with an `NSError`.
+    public let errorCode: Int
+    
+    /// Initialize using a description, domain, and code.
+    /// - parameters:
+    ///     - identifier: The identifier for the result.
+    ///     - description: The description of the error.
+    ///     - domain: The error domain.
+    ///     - code: The error code.
+    public init(identifier: String, description: String, domain: String, code: Int) {
+        self.identifier = identifier
+        self.startDate = Date()
+        self.endDate = Date()
+        self.errorDescription = description
+        self.errorDomain = domain
+        self.errorCode = code
+    }
+    
+    /// Initialize using an error.
+    /// - parameters:
+    ///     - identifier: The identifier for the result.
+    ///     - error: The error for the result.
+    public init(identifier: String, error: Error) {
+        self.identifier = identifier
+        self.startDate = Date()
+        self.endDate = Date()
+        self.errorDescription = (error as NSError).localizedDescription
+        self.errorDomain = (error as NSError).domain
+        self.errorCode = (error as NSError).code
+    }
+}
+
+extension ErrorResultObject : DocumentableStruct {
+    public static func codingKeys() -> [CodingKey] {
+        return CodingKeys.allCases
+    }
+    
+    public static func isRequired(_ codingKey: CodingKey) -> Bool {
+        true
+    }
+    
+    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
+        guard let key = codingKey as? CodingKeys else {
+            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
+        }
+        switch key {
+        case .serializableResultType:
+            return .init(constValue: SerializableResultType.error)
+        case .identifier:
+            return .init(propertyType: .primitive(.string))
+        case .startDate, .endDate:
+            return .init(propertyType: .format(.dateTime))
+        case .errorDomain, .errorDescription:
+            return .init(propertyType: .primitive(.string))
+        case .errorCode:
+            return .init(propertyType: .primitive(.integer))
+        }
+    }
+    
+    public static func examples() -> [ErrorResultObject] {
+        return [ErrorResultObject(identifier: "errorResult", description: "example error", domain: "ExampleDomain", code: 1)]
+    }
+}

--- a/Sources/JsonModel/ResultData/FileResultObject.swift
+++ b/Sources/JsonModel/ResultData/FileResultObject.swift
@@ -1,0 +1,113 @@
+//
+//  FileResultObject.swift
+//  
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `FileResultObject` is a concrete implementation of a result that holds a pointer to a file url.
+public final class FileResultObject : SerializableResultData {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case serializableResultType="type", identifier, startDate, endDate, relativePath, contentType, startUptime
+    }
+    public private(set) var serializableResultType: SerializableResultType = .file
+    
+    public let identifier: String
+    public var startDate: Date
+    public var endDate: Date
+    
+    /// The system clock uptime when the recorder was started (if applicable).
+    public var startUptime: TimeInterval?
+    
+    /// The URL with the full path to the file-based result. This should *not*
+    /// be encoded in the file result.
+    public var url: URL? {
+        get { return _url }
+        set {
+            _url = newValue
+            relativePath = newValue?.relativePath
+        }
+    }
+    private var _url: URL? = nil
+    
+    /// The relative path to the file-based result.
+    public var relativePath: String?
+    
+    /// The MIME content type of the result.
+    public var contentType: String?
+    
+    public init(identifier: String, url: URL? = nil, contentType: String? = nil, startUptime: TimeInterval? = nil) {
+        self.identifier = identifier
+        self._url = url
+        self.relativePath = url?.relativePath
+        self.contentType = contentType
+        self.startUptime = startUptime
+        self.startDate = Date()
+        self.endDate = Date()
+    }
+}
+
+extension FileResultObject : DocumentableStruct {
+    public static func codingKeys() -> [CodingKey] {
+        return CodingKeys.allCases
+    }
+    
+    public static func isRequired(_ codingKey: CodingKey) -> Bool {
+        guard let key = codingKey as? CodingKeys else { return false }
+        return key == .identifier || key == .serializableResultType
+    }
+    
+    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
+        guard let key = codingKey as? CodingKeys else {
+            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
+        }
+        switch key {
+        case .serializableResultType:
+            return .init(constValue: SerializableResultType.file)
+        case .identifier:
+            return .init(propertyType: .primitive(.string))
+        case .startDate, .endDate:
+            return .init(propertyType: .format(.dateTime))
+        case .contentType, .relativePath:
+            return .init(propertyType: .primitive(.string))
+        case .startUptime:
+            return .init(propertyType: .primitive(.number))
+        }
+    }
+    
+    public static func examples() -> [FileResultObject] {
+        let fileResult = FileResultObject(identifier: "fileResult")
+        fileResult.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
+        fileResult.endDate = fileResult.startDate.addingTimeInterval(5 * 60)
+        fileResult.startUptime = 1234.567
+        return [fileResult]
+    }
+}

--- a/Sources/JsonModel/ResultData/JsonElementResultObject.swift
+++ b/Sources/JsonModel/ResultData/JsonElementResultObject.swift
@@ -1,0 +1,93 @@
+//
+//  JsonElementResultObject.swift
+//  
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `JsonElementResultObject` is a `ResultData` implementation that can be used to store simple
+/// json values.
+public final class JsonElementResultObject : SerializableResultData {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case serializableResultType="type", identifier, jsonValue="value", startDate, endDate
+    }
+    public private(set) var serializableResultType: SerializableResultType = .jsonValue
+    
+    public let identifier: String
+    public var jsonValue: JsonElement?
+    public var startDate: Date
+    public var endDate: Date
+    
+    public init(identifier: String, value: JsonElement, questionText: String? = nil) {
+        self.identifier = identifier
+        self.startDate = Date()
+        self.endDate = Date()
+        self.jsonValue = value
+    }
+}
+
+extension JsonElementResultObject : DocumentableStruct {
+    public static func codingKeys() -> [CodingKey] {
+        CodingKeys.allCases
+    }
+    
+    public static func isRequired(_ codingKey: CodingKey) -> Bool {
+        guard let key = codingKey as? CodingKeys else { return false }
+        return key == .serializableResultType || key == .identifier || key == .startDate || key == .endDate
+    }
+    
+    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
+        guard let key = codingKey as? CodingKeys else {
+            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
+        }
+        switch key {
+        case .serializableResultType:
+            return .init(constValue: SerializableResultType.jsonValue)
+        case .identifier:
+            return .init(propertyType: .primitive(.string))
+        case .startDate, .endDate:
+            return .init(propertyType: .format(.dateTime))
+        case .jsonValue:
+            return .init(propertyType: .any)
+        }
+    }
+
+    public static func examples() -> [JsonElementResultObject] {
+        let date = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
+        let values: [JsonElement] = [.string("foo"), .integer(42), .boolean(true)]
+        return values.enumerated().map {
+            let result = JsonElementResultObject(identifier: "\($0.offset)", value: $0.element)
+            result.startDate = date
+            result.endDate = date
+            return result
+        }
+    }
+}

--- a/Sources/JsonModel/ResultData/ResultData.swift
+++ b/Sources/JsonModel/ResultData/ResultData.swift
@@ -37,14 +37,14 @@ import Foundation
 ///  syoung 12/09/2020 `ResultData` is included as a part of the JsonModel module to allow
 ///  progress and additions to be made to the frameworks used by SageResearch that are independant
 ///  of the version of https://github.com/Sage-Bionetworks/SageResearch-Apple.git that is
-///  referenced by third-party frameworks. Our experience is that third-party developers will to
+///  referenced by third-party frameworks. Our experience is that third-party developers will
 ///  pin to a specific version of SageResearch, which breaks the dependency model that we use
 ///  internally in our applications.
 ///
 ///  The work-around to this is to include a light-weight model here since this framework is fairly
 ///  static and in most cases where the `RSDResult` is referenced, those classes already import
 ///  JsonModel. This will allow us to divorce *our* code from SageResearch so that we can iterate
-///  independantly of third-party frameworks.
+///  independently of third-party frameworks.
 ///
 public protocol ResultData : PolymorphicTyped, DictionaryRepresentable {
     
@@ -57,4 +57,3 @@ public protocol ResultData : PolymorphicTyped, DictionaryRepresentable {
     /// The end date timestamp for the result.
     var endDate: Date { get set }
 }
-

--- a/Sources/JsonModel/ResultData/ResultData.swift
+++ b/Sources/JsonModel/ResultData/ResultData.swift
@@ -1,0 +1,60 @@
+//
+//  ResultData.swift
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `ResultData` is the base protocol for an object that stores data.
+///
+///  syoung 12/09/2020 `ResultData` is included as a part of the JsonModel module to allow
+///  progress and additions to be made to the frameworks used by SageResearch that are independant
+///  of the version of https://github.com/Sage-Bionetworks/SageResearch-Apple.git that is
+///  referenced by third-party frameworks. Our experience is that third-party developers will to
+///  pin to a specific version of SageResearch, which breaks the dependency model that we use
+///  internally in our applications.
+///
+///  The work-around to this is to include a light-weight model here since this framework is fairly
+///  static and in most cases where the `RSDResult` is referenced, those classes already import
+///  JsonModel. This will allow us to divorce *our* code from SageResearch so that we can iterate
+///  independantly of third-party frameworks.
+///
+public protocol ResultData : PolymorphicTyped, DictionaryRepresentable {
+    
+    /// The identifier associated with the task, step, or asynchronous action.
+    var identifier: String { get }
+    
+    /// The start date timestamp for the result.
+    var startDate: Date { get set }
+    
+    /// The end date timestamp for the result.
+    var endDate: Date { get set }
+}
+

--- a/Sources/JsonModel/ResultData/ResultDataFactory.swift
+++ b/Sources/JsonModel/ResultData/ResultDataFactory.swift
@@ -1,0 +1,138 @@
+//
+//  ResultDataFactory.swift
+//  
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `ResultDataFactory` is a subclass of the `SerializationFactory` that registers a serializer
+/// for `JsonResultData` objects that can be used to deserialize the results.
+open class ResultDataFactory : SerializationFactory {
+    
+    public let resultSerializer = ResultDataSerializer()
+    
+    public required init() {
+        super.init()
+        self.registerSerializer(resultSerializer)
+    }
+}
+
+/// `SerializableResultData` is the base implementation for `ResultData` that is serialized using
+/// the `Codable` protocol and the polymorphic serialization defined by this framework.
+///
+public protocol SerializableResultData : ResultData, PolymorphicRepresentable, Encodable {
+    var serializableResultType: SerializableResultType { get }
+}
+
+extension SerializableResultData {
+    public var typeName: String { serializableResultType.stringValue }
+    
+    public func jsonDictionary() throws -> [String : JsonSerializable] {
+        try jsonEncodedDictionary()
+    }
+}
+
+/// `SerializableResultType` is an extendable string enum used by the `SerializationFactory` to
+/// create the appropriate result type.
+public struct SerializableResultType : TypeRepresentable, Codable, Hashable {
+    
+    public let rawValue: String
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    /// Defaults to creating a `JsonElementResultObject`.
+    public static let jsonValue: SerializableResultType = "jsonValue"
+
+    /// Defaults to creating a `CollectionResultObject`.
+    public static let collection: SerializableResultType = "collection"
+
+    /// Defaults to creating a `FileResultObject`.
+    public static let file: SerializableResultType = "file"
+
+    /// Defaults to creating a `ErrorResultObject`.
+    public static let error: SerializableResultType = "error"
+    
+    /// List of all the standard types.
+    public static func allStandardTypes() -> [SerializableResultType] {
+        [.jsonValue, .collection, .file, .error]
+    }
+}
+
+extension SerializableResultType : ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value)
+    }
+}
+
+extension SerializableResultType : DocumentableStringLiteral {
+    public static func examples() -> [String] {
+        return allStandardTypes().map{ $0.rawValue }
+    }
+}
+
+public final class ResultDataSerializer : IdentifiableInterfaceSerializer, PolymorphicSerializer {
+    public var documentDescription: String? {
+        """
+        `JsonResultData` is the base implementation for `ResultData` that is serialized using
+        the `Codable` protocol and the polymorphic serialization defined by this framework.
+        """.replacingOccurrences(of: "\n", with: " ").replacingOccurrences(of: "  ", with: "\n")
+    }
+    
+    override init() {
+        self.examples = [
+            JsonElementResultObject.examples().first!,
+            CollectionResultObject.examples().first!,
+            ErrorResultObject.examples().first!,
+            FileResultObject.examples().first!,
+        ]
+    }
+    
+    public private(set) var examples: [ResultData]
+    
+    public override class func typeDocumentProperty() -> DocumentProperty {
+        .init(propertyType: .reference(SerializableResultType.documentableType()))
+    }
+    
+    public func add(_ example: SerializableResultData) {
+        examples.removeAll(where: { $0.typeName == example.typeName })
+        examples.append(example)
+    }
+    
+    /// Insert the given examples into the example array, replacing any existing examples with the
+    /// same `typeName` as one of the new examples.
+    public func add(contentsOf newExamples: [SerializableResultData]) {
+        let newNames = newExamples.map { $0.typeName }
+        self.examples.removeAll(where: { newNames.contains($0.typeName) })
+        self.examples.append(contentsOf: newExamples)
+    }
+}

--- a/Sources/JsonModel/SerializationFactory.swift
+++ b/Sources/JsonModel/SerializationFactory.swift
@@ -81,6 +81,10 @@ open class SerializationFactory : FactoryRegistration {
         serializerMap[serializer.interfaceName] = serializer
     }
     
+    public final func registerSerializer<T>(_ serializer: GenericSerializer, for type: T.Type) {
+        serializerMap["\(type)"] = serializer
+    }
+    
     open func serializer<T>(for type: T.Type) -> GenericSerializer? {
         serializerMap["\(type)"]
     }

--- a/Tests/JsonModelTests/AnyCodableTests.swift
+++ b/Tests/JsonModelTests/AnyCodableTests.swift
@@ -200,6 +200,16 @@ final class AnyCodableTests: XCTestCase {
             let dictionary = try test.jsonEncodedDictionary()
             XCTAssertEqual(expected as NSDictionary, dictionary as NSDictionary)
             
+            let data = try test.jsonEncodedData()
+            let obj = try SerializationFactory.defaultFactory.createJSONDecoder().decode(TestDecodable.self, from: data)
+            XCTAssertEqual(test.string, obj.string)
+            XCTAssertEqual(test.integer, obj.integer)
+            XCTAssertEqual(test.uuid, obj.uuid)
+            XCTAssertEqual(test.date.timeIntervalSinceReferenceDate, obj.date.timeIntervalSinceReferenceDate, accuracy: 1)
+            XCTAssertEqual(test.bool, obj.bool)
+            XCTAssertEqual(test.array, obj.array)
+            XCTAssertEqual(test.null, obj.null)
+
         } catch let err {
             XCTFail("Failed to decode/encode object: \(err)")
             return

--- a/Tests/JsonModelTests/ResultDataTests.swift
+++ b/Tests/JsonModelTests/ResultDataTests.swift
@@ -1,0 +1,131 @@
+//
+//  ResultDataTests.swift
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import XCTest
+@testable import JsonModel
+
+class ResultDataTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testCreateJsonSchemaDocumentation() {
+        let factory = ResultDataFactory()
+        let baseUrl = URL(string: "http://sagebionetworks.org/SageResearch/jsonSchema/")!
+        
+        let doc = JsonDocumentBuilder(baseUrl: baseUrl,
+                                      factory: factory,
+                                      rootDocuments: [])
+        
+        do {
+            let _ = try doc.buildSchemas()
+        }
+        catch let err {
+            XCTFail("Failed to build the JsonSchema: \(err)")
+        }
+    }
+    
+    func testSerializers() {
+        let factory = ResultDataFactory()
+        
+        XCTAssertTrue(checkPolymorphicExamples(for: factory.resultSerializer.examples,
+                                                using: factory, protocolType: ResultData.self))
+
+    }
+    
+    func checkPolymorphicExamples<ProtocolType>(for objects: [ProtocolType], using factory: SerializationFactory, protocolType: ProtocolType.Type) -> Bool {
+        var success = true
+        objects.forEach {
+            guard let original = $0 as? DocumentableObject else {
+                XCTFail("Object does not conform to DocumentableObject. \($0)")
+                success = false
+                return
+            }
+
+            do {
+                let decoder = factory.createJSONDecoder()
+                let examples = try type(of: original).jsonExamples()
+                examples.forEach { example in
+                    do {
+                        // Check that the example can be decoded without errors.
+                        let wrapper = example.jsonObject()
+                        let encodedObject = try JSONSerialization.data(withJSONObject: wrapper, options: [])
+                        let decodingWrapper = try decoder.decode(_DecodablePolymorphicWrapper.self, from: encodedObject)
+                        let decodedObject = try factory.decodePolymorphicObject(protocolType, from: decodingWrapper.decoder)
+                        
+                        // Check that the decoded object is the same Type as the original.
+                        let originalType = type(of: original as Any)
+                        let decodedType = type(of: decodedObject as Any)
+                        let isSameType = (originalType == decodedType)
+                        XCTAssertTrue(isSameType, "\(decodedType) is not equal to \(originalType)")
+                        success = success && isSameType
+                        
+                        // Check that the decoded type name is the same as the original type name
+                        guard let decodedTypeName = (decodedObject as? PolymorphicRepresentable)?.typeName
+                            else {
+                                XCTFail("Decoded object does not conform to PolymorphicRepresentable. \(decodedObject)")
+                                return
+                        }
+                        guard let originalTypeName = (original as? PolymorphicRepresentable)?.typeName
+                            else {
+                                XCTFail("Example object does not conform to PolymorphicRepresentable. \(original)")
+                                return
+                        }
+                        XCTAssertEqual(originalTypeName, decodedTypeName)
+                        success = success && (originalTypeName == decodedTypeName)
+                        
+                    } catch let err {
+                        XCTFail("Failed to decode \(example) for \(protocolType). \(err)")
+                        success = false
+                    }
+                }
+            }
+            catch let err {
+                XCTFail("Failed to decode \(original). \(err)")
+                success = false
+            }
+        }
+        return success
+    }
+    
+    fileprivate struct _DecodablePolymorphicWrapper : Decodable {
+        let decoder: Decoder
+        init(from decoder: Decoder) throws {
+            self.decoder = decoder
+        }
+    }
+}


### PR DESCRIPTION
Looking at the recorders, I realized that in order to move forward with *not* requiring an iOS implementation of our recorders or our Kotlin-Native stuff to also support all the protocols within SageResearch-Apple, it was going to be easier to maintain in the smaller, lighter-weight, SwiftPM *only* JsonModel. I added to the existing JsonModel Swift module b/c any implementations of RSDResult will already import that module so migration should be simpler.

The `ResultData` intentionally does *not* conform to the `Codable` protocol so that it can conform to Kotlin-Native encoded objects without having to wire up the polymorphic decoding stuff (since these *can* be used to encode to JSON without requiring that it also decode from JSON - eg. Kotlin or Obj-C classes).

https://github.com/Sage-Bionetworks/SageResearch/pull/225 has the changes required to support this in SageResearch. That PR is marked as draft b/c it points at a branch.

Note: Github actions are so cool. 😎 