### PR TITLE
Migrate `RSDResult` to `ResultData`

### DIFF
--- a/Sources/JsonModel/Deprecated/JsonElementResultObject.swift
+++ b/Sources/JsonModel/Deprecated/JsonElementResultObject.swift
@@ -48,15 +48,15 @@ public final class JsonElementResultObject : SerializableResultData, AnswerResul
     public var startDate: Date
     public var endDate: Date
     
-    public var codingInfo: AnswerCodingInfo? { _codingInfo }
-    private var _codingInfo: AnswerCodingInfo? = nil
+    public var answerType: AnswerType? { _answerType }
+    private var _answerType: AnswerType? = nil
     
     public init(identifier: String, value: JsonElement, questionText: String? = nil) {
         self.identifier = identifier
         self.startDate = Date()
         self.endDate = Date()
         self.jsonValue = value
-        self._codingInfo = value.codingInfo
+        self._answerType = value.answerType
         self.questionText = questionText
     }
     

--- a/Sources/JsonModel/Deprecated/JsonElementResultObject.swift
+++ b/Sources/JsonModel/Deprecated/JsonElementResultObject.swift
@@ -48,7 +48,7 @@ public final class JsonElementResultObject : SerializableResultData, AnswerResul
     public var startDate: Date
     public var endDate: Date
     
-    public var answerType: AnswerType? { _answerType }
+    public var jsonAnswerType: AnswerType? { _answerType }
     private var _answerType: AnswerType? = nil
     
     public init(identifier: String, value: JsonElement, questionText: String? = nil) {

--- a/Sources/JsonModel/Encodable+Utilities.swift
+++ b/Sources/JsonModel/Encodable+Utilities.swift
@@ -54,8 +54,7 @@ extension Encodable {
         return dictionary
     }
     
-    /// Returns JSON-encoded data created by encoding this object using a JSON encoder created
-    /// by the shared `RSDFactory` singleton.
+    /// Returns JSON-encoded data created by encoding this object.
     public func jsonEncodedData(using factory: SerializationFactory = SerializationFactory.defaultFactory) throws -> Data {
         let jsonEncoder = factory.createJSONEncoder()
         return try self.encodeObject(to: jsonEncoder)

--- a/Sources/JsonModel/ResourceInfo.swift
+++ b/Sources/JsonModel/ResourceInfo.swift
@@ -68,7 +68,7 @@ extension Bundle : ResourceBundle {
 }
 
 
-/// `RSDDecodableBundleInfo` is a convenience protocol for setting the resource information on a
+/// `DecodableBundleInfo` is a convenience protocol for setting the resource information on a
 /// decoded object.
 public protocol DecodableBundleInfo : Decodable, ResourceInfo {
     

--- a/Sources/JsonModel/ResultData/AnswerType.swift
+++ b/Sources/JsonModel/ResultData/AnswerType.swift
@@ -1,5 +1,5 @@
 //
-//  AnswerCodingInfo.swift
+//  AnswerType.swift
 //
 //
 //  Copyright © 2020-2021 Sage Bionetworks. All rights reserved.
@@ -36,7 +36,7 @@ import Foundation
 /// The coding information for an answer. This allows for adding custom information to the "kind" of question because
 /// JSON only supports a small subset of value types that are often encoded and can be described using JSON Schema
 /// or Swagger.
-public protocol AnswerCodingInfo : PolymorphicTyped, DictionaryRepresentable {
+public protocol AnswerType : PolymorphicTyped, DictionaryRepresentable {
 
     /// The `JsonType` for the base value.
     var baseType: JsonType { get }
@@ -62,34 +62,34 @@ public protocol AnswerCodingInfo : PolymorphicTyped, DictionaryRepresentable {
     func encodeAnswer(from value: Any?) throws -> JsonElement
 }
 
-public final class AnswerCodingInfoSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
+public final class AnswerTypeSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
     public var documentDescription: String? {
         """
-        `AnswerCodingInfo` is used to allow carrying additional information about the properties of a
+        `AnswerType` is used to allow carrying additional information about the properties of a
         JSON-encoded `AnswerResult`.
         """.replacingOccurrences(of: "\n", with: " ").replacingOccurrences(of: "  ", with: "\n")
     }
     
     override init() {
         examples = [
-            AnswerCodingInfoArray.examples().first!,
-            AnswerCodingInfoBoolean.examples().first!,
-            AnswerCodingInfoDateTime.examples().first!,
-            AnswerCodingInfoInteger.examples().first!,
-            AnswerCodingInfoMeasurement.examples().first!,
-            AnswerCodingInfoNumber.examples().first!,
-            AnswerCodingInfoObject.examples().first!,
-            AnswerCodingInfoString.examples().first!,
+            AnswerTypeArray.examples().first!,
+            AnswerTypeBoolean.examples().first!,
+            AnswerTypeDateTime.examples().first!,
+            AnswerTypeInteger.examples().first!,
+            AnswerTypeMeasurement.examples().first!,
+            AnswerTypeNumber.examples().first!,
+            AnswerTypeObject.examples().first!,
+            AnswerTypeString.examples().first!,
         ]
     }
     
-    public private(set) var examples: [AnswerCodingInfo]
+    public private(set) var examples: [AnswerType]
     
     public override class func typeDocumentProperty() -> DocumentProperty {
-        .init(propertyType: .reference(AnswerCodingInfoType.documentableType()))
+        .init(propertyType: .reference(AnswerTypeType.documentableType()))
     }
     
-    public func add(_ example: AnswerCodingInfo) {
+    public func add(_ example: AnswerType) {
         if let idx = examples.firstIndex(where: { $0.typeName == example.typeName }) {
             examples.remove(at: idx)
         }
@@ -97,11 +97,11 @@ public final class AnswerCodingInfoSerializer : AbstractPolymorphicSerializer, P
     }
 }
 
-public protocol SerializableAnswerCodingInfo : AnswerCodingInfo, PolymorphicRepresentable, Encodable {
-    var serializableType: AnswerCodingInfoType { get }
+public protocol SerializableAnswerType : AnswerType, PolymorphicRepresentable, Encodable {
+    var serializableType: AnswerTypeType { get }
 }
 
-extension SerializableAnswerCodingInfo {
+extension SerializableAnswerType {
     public var typeName: String { serializableType.stringValue }
     
     public func jsonDictionary() throws -> [String : JsonSerializable] {
@@ -109,7 +109,7 @@ extension SerializableAnswerCodingInfo {
     }
 }
 
-public struct AnswerCodingInfoType : TypeRepresentable, Codable, Hashable {
+public struct AnswerTypeType : TypeRepresentable, Codable, Hashable {
     public let rawValue: String
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -119,38 +119,38 @@ public struct AnswerCodingInfoType : TypeRepresentable, Codable, Hashable {
         self.rawValue = jsonType.rawValue
     }
     
-    static public let measurement: AnswerCodingInfoType = "measurement"
-    static public let dateTime: AnswerCodingInfoType = "date-time"
-    static public let string: AnswerCodingInfoType = AnswerCodingInfoType(jsonType: .string)
-    static public let number: AnswerCodingInfoType = AnswerCodingInfoType(jsonType: .number)
-    static public let integer: AnswerCodingInfoType = AnswerCodingInfoType(jsonType: .integer)
-    static public let boolean: AnswerCodingInfoType = AnswerCodingInfoType(jsonType: .boolean)
-    static public let array: AnswerCodingInfoType = AnswerCodingInfoType(jsonType: .array)
-    static public let object: AnswerCodingInfoType = AnswerCodingInfoType(jsonType: .object)
-    static public let null: AnswerCodingInfoType = AnswerCodingInfoType(jsonType: .null)
+    static public let measurement: AnswerTypeType = "measurement"
+    static public let dateTime: AnswerTypeType = "date-time"
+    static public let string: AnswerTypeType = AnswerTypeType(jsonType: .string)
+    static public let number: AnswerTypeType = AnswerTypeType(jsonType: .number)
+    static public let integer: AnswerTypeType = AnswerTypeType(jsonType: .integer)
+    static public let boolean: AnswerTypeType = AnswerTypeType(jsonType: .boolean)
+    static public let array: AnswerTypeType = AnswerTypeType(jsonType: .array)
+    static public let object: AnswerTypeType = AnswerTypeType(jsonType: .object)
+    static public let null: AnswerTypeType = AnswerTypeType(jsonType: .null)
     
-    static func allStandardTypes() -> [AnswerCodingInfoType] {
+    static func allStandardTypes() -> [AnswerTypeType] {
         return [.array, .boolean, .dateTime, .integer, .measurement, .null, .number, .object]
     }
 }
 
-extension AnswerCodingInfoType : ExpressibleByStringLiteral {
+extension AnswerTypeType : ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }
 }
 
-extension AnswerCodingInfoType : DocumentableStringLiteral {
+extension AnswerTypeType : DocumentableStringLiteral {
     public static func examples() -> [String] {
         allStandardTypes().map { $0.rawValue }
     }
 }
 
-public protocol BaseAnswerCodingInfo : SerializableAnswerCodingInfo {
+public protocol BaseAnswerType : SerializableAnswerType {
     static var defaultJsonType: JsonType { get }
 }
 
-extension BaseAnswerCodingInfo {
+extension BaseAnswerType {
     public var typeName: String { serializableType.rawValue }
     
     public var baseType: JsonType {
@@ -159,27 +159,27 @@ extension BaseAnswerCodingInfo {
 }
 
 extension JsonType {
-    public var AnswerCodingInfo : AnswerCodingInfo {
+    public var AnswerType : AnswerType {
         switch self {
         case .boolean:
-            return AnswerCodingInfoBoolean()
+            return AnswerTypeBoolean()
         case .string:
-            return AnswerCodingInfoString()
+            return AnswerTypeString()
         case .number:
-            return AnswerCodingInfoNumber()
+            return AnswerTypeNumber()
         case .integer:
-            return AnswerCodingInfoInteger()
+            return AnswerTypeInteger()
         case .null:
-            return AnswerCodingInfoNull()
+            return AnswerTypeNull()
         case .array:
-            return AnswerCodingInfoArray()
+            return AnswerTypeArray()
         case .object:
-            return AnswerCodingInfoObject()
+            return AnswerTypeObject()
         }
     }
 }
 
-extension AnswerCodingInfo {
+extension AnswerType {
     fileprivate func decodingError(_ codingPath: [CodingKey] = []) -> DecodingError {
         let context = DecodingError.Context(codingPath: codingPath,
                                             debugDescription: "Could not decode the value into the expected JsonType for \(self)")
@@ -192,13 +192,13 @@ extension AnswerCodingInfo {
     }
 }
 
-public struct AnswerCodingInfoObject : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeObject : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type"
     }
     public static let defaultJsonType: JsonType = .object
-    public static let defaultType: AnswerCodingInfoType = .object
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .object
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public init() {
     }
     
@@ -234,13 +234,13 @@ public struct AnswerCodingInfoObject : BaseAnswerCodingInfo, Codable, Hashable {
     }
 }
 
-public struct AnswerCodingInfoString : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeString : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type"
     }
     public static let defaultJsonType: JsonType = .string
-    public static let defaultType: AnswerCodingInfoType = .string
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .string
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public init() {
     }
     
@@ -278,13 +278,13 @@ public struct AnswerCodingInfoString : BaseAnswerCodingInfo, Codable, Hashable {
     }
 }
 
-public struct AnswerCodingInfoBoolean : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeBoolean : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type"
     }
     public static let defaultJsonType: JsonType = .boolean
-    public static let defaultType: AnswerCodingInfoType = .boolean
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .boolean
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public init() {
     }
     
@@ -334,13 +334,13 @@ public struct AnswerCodingInfoBoolean : BaseAnswerCodingInfo, Codable, Hashable 
     }
 }
 
-public struct AnswerCodingInfoInteger : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeInteger : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type"
     }
     public static let defaultJsonType: JsonType = .integer
-    public static let defaultType: AnswerCodingInfoType = .integer
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .integer
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public init() {
     }
     
@@ -386,23 +386,23 @@ public struct AnswerCodingInfoInteger : BaseAnswerCodingInfo, Codable, Hashable 
     }
 }
 
-public struct AnswerCodingInfoNumber : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeNumber : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type"
     }
     public static let defaultJsonType: JsonType = .number
-    public static let defaultType: AnswerCodingInfoType = .number
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .number
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public init() {
     }
 }
-extension AnswerCodingInfoNumber : RSDNumberAnswerCodingInfo {
+extension AnswerTypeNumber : NumberJsonType {
 }
 
-protocol RSDNumberAnswerCodingInfo : AnswerCodingInfo {
+protocol NumberJsonType : AnswerType {
 }
 
-extension RSDNumberAnswerCodingInfo {
+extension NumberJsonType {
     public func decodeValue(from decoder: Decoder) throws -> JsonElement {
         let obj = try JsonElement(from: decoder)
         switch obj {
@@ -445,13 +445,13 @@ extension RSDNumberAnswerCodingInfo {
     }
 }
 
-public struct AnswerCodingInfoNull : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeNull : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type"
     }
     public static let defaultJsonType: JsonType = .null
-    public static let defaultType: AnswerCodingInfoType = .null
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .null
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public init() {
     }
     
@@ -468,12 +468,12 @@ public struct AnswerCodingInfoNull : BaseAnswerCodingInfo, Codable, Hashable {
     }
 }
 
-public struct AnswerCodingInfoArray : SerializableAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeArray : SerializableAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type", baseType, sequenceSeparator
     }
-    public static let defaultType: AnswerCodingInfoType = .array
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .array
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public let baseType: JsonType
     public let sequenceSeparator: String?
     public init(baseType: JsonType = .string, sequenceSeparator: String? = nil) {
@@ -502,7 +502,7 @@ public struct AnswerCodingInfoArray : SerializableAnswerCodingInfo, Codable, Has
                     return $0
                 default:
                     let context = DecodingError.Context(codingPath: codingPath,
-                                                        debugDescription: "A base type of `object` is not valid for an AnswerCodingInfoArray with a non-nil separator")
+                                                        debugDescription: "A base type of `object` is not valid for an AnswerTypeArray with a non-nil separator")
                     throw DecodingError.dataCorrupted(context)
                 }
             }
@@ -546,13 +546,13 @@ public struct AnswerCodingInfoArray : SerializableAnswerCodingInfo, Codable, Has
     }
 }
 
-public struct AnswerCodingInfoDateTime : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeDateTime : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type", _codingFormat = "codingFormat"
     }
     public static let defaultJsonType: JsonType = .string
-    public static let defaultType: AnswerCodingInfoType = .dateTime
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .dateTime
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     
     public var codingFormat: String {
         _codingFormat ?? ISO8601TimestampFormatter.dateFormat
@@ -605,127 +605,127 @@ public struct AnswerCodingInfoDateTime : BaseAnswerCodingInfo, Codable, Hashable
     }
 }
 
-public struct AnswerCodingInfoMeasurement : BaseAnswerCodingInfo, Codable, Hashable {
+public struct AnswerTypeMeasurement : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case serializableType = "type", unit
     }
     public static let defaultJsonType: JsonType = .number
-    public static let defaultType: AnswerCodingInfoType = .measurement
-    public private(set) var serializableType: AnswerCodingInfoType = Self.defaultType
+    public static let defaultType: AnswerTypeType = .measurement
+    public private(set) var serializableType: AnswerTypeType = Self.defaultType
     public let unit: String?
     
     public init(unit: String? = nil) {
         self.unit = unit
     }
 }
-extension AnswerCodingInfoMeasurement : RSDNumberAnswerCodingInfo {
+extension AnswerTypeMeasurement : NumberJsonType {
 }
 
 // MARK: Documentable
 
-protocol AnswerCodingInfoDocumentable {
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)]
+protocol AnswerTypeDocumentable {
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)]
 }
 
-struct AnswerCodingInfoExamples {
+struct AnswerTypeExamples {
     
-    static func examplesWithValues() -> [(AnswerCodingInfo, JsonElement)] {
+    static func examplesWithValues() -> [(AnswerType, JsonElement)] {
         documentableTypes.flatMap { $0.exampleTypeAndValues() }
     }
     
-    static let documentableTypes: [AnswerCodingInfoDocumentable.Type] = [
-        AnswerCodingInfoBoolean.self,
-        AnswerCodingInfoInteger.self,
-        AnswerCodingInfoNumber.self,
-        AnswerCodingInfoObject.self,
-        AnswerCodingInfoString.self,
-        AnswerCodingInfoArray.self,
-        AnswerCodingInfoDateTime.self,
-        AnswerCodingInfoMeasurement.self,
+    static let documentableTypes: [AnswerTypeDocumentable.Type] = [
+        AnswerTypeBoolean.self,
+        AnswerTypeInteger.self,
+        AnswerTypeNumber.self,
+        AnswerTypeObject.self,
+        AnswerTypeString.self,
+        AnswerTypeArray.self,
+        AnswerTypeDateTime.self,
+        AnswerTypeMeasurement.self,
     ]
 }
 
-extension AnswerCodingInfoObject : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeObject : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
     public static func isRequired(_ codingKey: CodingKey) -> Bool { true }
     public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
         .init(constValue: defaultType)
     }
     
-    public static func examples() -> [AnswerCodingInfoObject] {
+    public static func examples() -> [AnswerTypeObject] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
 
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
-        [(AnswerCodingInfoObject(), .object(["foo":"ba"]))]
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
+        [(AnswerTypeObject(), .object(["foo":"ba"]))]
     }
 }
 
-extension AnswerCodingInfoString : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeString : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
     public static func isRequired(_ codingKey: CodingKey) -> Bool { true }
     public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
         .init(constValue: defaultType)
     }
 
-    public static func examples() -> [AnswerCodingInfoString] {
+    public static func examples() -> [AnswerTypeString] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
 
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
-        [(AnswerCodingInfoString(), .string("foo"))]
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
+        [(AnswerTypeString(), .string("foo"))]
     }
 }
 
-extension AnswerCodingInfoBoolean : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeBoolean : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
     public static func isRequired(_ codingKey: CodingKey) -> Bool { true }
     public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
         .init(constValue: defaultType)
     }
 
-    public static func examples() -> [AnswerCodingInfoBoolean] {
+    public static func examples() -> [AnswerTypeBoolean] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
 
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
-        [(AnswerCodingInfoBoolean(), .boolean(true))]
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
+        [(AnswerTypeBoolean(), .boolean(true))]
     }
 }
 
-extension AnswerCodingInfoInteger : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeInteger : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
     public static func isRequired(_ codingKey: CodingKey) -> Bool { true }
     public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
         .init(constValue: defaultType)
     }
 
-    public static func examples() -> [AnswerCodingInfoInteger] {
+    public static func examples() -> [AnswerTypeInteger] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
 
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
-        [(AnswerCodingInfoInteger(), .integer(42))]
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
+        [(AnswerTypeInteger(), .integer(42))]
     }
 }
 
-extension AnswerCodingInfoNumber : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeNumber : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
     public static func isRequired(_ codingKey: CodingKey) -> Bool { true }
     public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
         .init(constValue: defaultType)
     }
 
-    public static func examples() -> [AnswerCodingInfoNumber] {
+    public static func examples() -> [AnswerTypeNumber] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
 
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
-        [(AnswerCodingInfoNumber(), .number(3.14))]
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
+        [(AnswerTypeNumber(), .number(3.14))]
     }
 }
 
-extension AnswerCodingInfoArray : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeArray : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
     
     public static func isRequired(_ codingKey: CodingKey) -> Bool {
@@ -747,20 +747,20 @@ extension AnswerCodingInfoArray : AnswerCodingInfoDocumentable, DocumentableStru
         }
     }
 
-    public static func examples() -> [AnswerCodingInfoArray] {
+    public static func examples() -> [AnswerTypeArray] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
     
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
         [
-            (AnswerCodingInfoArray(baseType: .number), .array([3.2, 5.1])),
-            (AnswerCodingInfoArray(baseType: .integer), .array([1, 5])),
-            (AnswerCodingInfoArray(baseType: .string), .array(["foo", "ba", "lalala"])),
+            (AnswerTypeArray(baseType: .number), .array([3.2, 5.1])),
+            (AnswerTypeArray(baseType: .integer), .array([1, 5])),
+            (AnswerTypeArray(baseType: .string), .array(["foo", "ba", "lalala"])),
         ]
     }
 }
 
-extension AnswerCodingInfoDateTime : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeDateTime : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
 
     public static func isRequired(_ codingKey: CodingKey) -> Bool {
@@ -780,20 +780,20 @@ extension AnswerCodingInfoDateTime : AnswerCodingInfoDocumentable, DocumentableS
         }
     }
 
-    public static func examples() -> [AnswerCodingInfoDateTime] {
+    public static func examples() -> [AnswerTypeDateTime] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
     
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
         [
-            (AnswerCodingInfoDateTime(codingFormat: "yyyy-MM"), .string("2020-04")),
-            (AnswerCodingInfoDateTime(codingFormat: "HH:mm"), .string("08:30")),
-            (AnswerCodingInfoDateTime(), .string("2017-10-16T22:28:09.000-07:00")),
+            (AnswerTypeDateTime(codingFormat: "yyyy-MM"), .string("2020-04")),
+            (AnswerTypeDateTime(codingFormat: "HH:mm"), .string("08:30")),
+            (AnswerTypeDateTime(), .string("2017-10-16T22:28:09.000-07:00")),
         ]
     }
 }
 
-extension AnswerCodingInfoMeasurement : AnswerCodingInfoDocumentable, DocumentableStruct {
+extension AnswerTypeMeasurement : AnswerTypeDocumentable, DocumentableStruct {
     public static func codingKeys() -> [CodingKey] { CodingKeys.allCases }
 
     public static func isRequired(_ codingKey: CodingKey) -> Bool {
@@ -813,40 +813,40 @@ extension AnswerCodingInfoMeasurement : AnswerCodingInfoDocumentable, Documentab
         }
     }
 
-    public static func examples() -> [AnswerCodingInfoMeasurement] {
+    public static func examples() -> [AnswerTypeMeasurement] {
         exampleTypeAndValues().map { $0.0 as! Self }
     }
     
-    static func exampleTypeAndValues() -> [(AnswerCodingInfo, JsonElement)] {
-        [(AnswerCodingInfoMeasurement(unit: "cm"), .number(170.2))]
+    static func exampleTypeAndValues() -> [(AnswerType, JsonElement)] {
+        [(AnswerTypeMeasurement(unit: "cm"), .number(170.2))]
     }
 }
 
 extension JsonElement {
-    var codingInfo: AnswerCodingInfo {
+    var answerType: AnswerType {
         switch self {
         case .null:
-            return AnswerCodingInfoNull()
+            return AnswerTypeNull()
         case .boolean(_):
-            return AnswerCodingInfoBoolean()
+            return AnswerTypeBoolean()
         case .string(_):
-            return AnswerCodingInfoString()
+            return AnswerTypeString()
         case .integer(_):
-            return AnswerCodingInfoInteger()
+            return AnswerTypeInteger()
         case .number(_):
-            return AnswerCodingInfoNumber()
+            return AnswerTypeNumber()
         case .array(let arr):
             if arr is [Int] {
-                return AnswerCodingInfoArray(baseType: .integer)
+                return AnswerTypeArray(baseType: .integer)
             } else if arr is [NSNumber] || arr is [JsonNumber] {
-                return AnswerCodingInfoArray(baseType: .number)
+                return AnswerTypeArray(baseType: .number)
             } else if arr is [String] {
-                return AnswerCodingInfoArray(baseType: .string)
+                return AnswerTypeArray(baseType: .string)
             } else {
-                return AnswerCodingInfoArray(baseType: .object)
+                return AnswerTypeArray(baseType: .object)
             }
         case .object(_):
-            return AnswerCodingInfoObject()
+            return AnswerTypeObject()
         }
     }
 }

--- a/Sources/JsonModel/ResultData/AnswerType.swift
+++ b/Sources/JsonModel/ResultData/AnswerType.swift
@@ -388,12 +388,14 @@ public struct AnswerTypeInteger : BaseAnswerType, Codable, Hashable {
 
 public struct AnswerTypeNumber : BaseAnswerType, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
-        case serializableType = "type"
+        case serializableType = "type", significantDigits
     }
     public static let defaultJsonType: JsonType = .number
     public static let defaultType: AnswerTypeType = .number
     public private(set) var serializableType: AnswerTypeType = Self.defaultType
-    public init() {
+    public let significantDigits: Int?
+    public init(significantDigits: Int? = nil) {
+        self.significantDigits = significantDigits
     }
 }
 extension AnswerTypeNumber : NumberJsonType {
@@ -846,6 +848,27 @@ extension JsonElement {
                 return AnswerTypeArray(baseType: .object)
             }
         case .object(_):
+            return AnswerTypeObject()
+        }
+    }
+}
+
+extension JsonType {
+    var answerType: AnswerType {
+        switch self {
+        case .string:
+            return AnswerTypeString()
+        case .number:
+            return AnswerTypeNumber()
+        case .integer:
+            return AnswerTypeInteger()
+        case .boolean:
+            return AnswerTypeBoolean()
+        case .null:
+            return AnswerTypeNull()
+        case .array:
+            return AnswerTypeArray()
+        case .object:
             return AnswerTypeObject()
         }
     }

--- a/Sources/JsonModel/ResultData/AnswerType.swift
+++ b/Sources/JsonModel/ResultData/AnswerType.swift
@@ -824,7 +824,7 @@ extension AnswerTypeMeasurement : AnswerTypeDocumentable, DocumentableStruct {
     }
 }
 
-extension JsonElement {
+public extension JsonElement {
     var answerType: AnswerType {
         switch self {
         case .null:
@@ -853,7 +853,7 @@ extension JsonElement {
     }
 }
 
-extension JsonType {
+public extension JsonType {
     var answerType: AnswerType {
         switch self {
         case .string:

--- a/Sources/JsonModel/ResultData/CollectionResult.swift
+++ b/Sources/JsonModel/ResultData/CollectionResult.swift
@@ -145,14 +145,7 @@ public final class CollectionResultObject : SerializableResultData, CollectionRe
         var nestedContainer = container.nestedUnkeyedContainer(forKey: .children)
         try children.forEach { result in
             let nestedEncoder = nestedContainer.superEncoder()
-            if let encodable = result as? Encodable {
-                try encodable.encode(to: nestedEncoder)
-            }
-            else {
-                let json = try result.jsonDictionary()
-                let element: JsonElement = .object(json)
-                try element.encode(to: nestedEncoder)
-            }
+            try result.encode(to: nestedEncoder)
         }
     }
 }

--- a/Sources/JsonModel/ResultData/CollectionResult.swift
+++ b/Sources/JsonModel/ResultData/CollectionResult.swift
@@ -113,11 +113,6 @@ public final class CollectionResultObject : SerializableResultData, CollectionRe
         self.endDate = Date()
     }
     
-    /// Initialize from a `Decoder`. This decoding method will use the `RSDFactory` instance associated
-    /// with the decoder to decode the `inputResults`.
-    ///
-    /// - parameter decoder: The decoder to use to decode this instance.
-    /// - throws: `DecodingError`
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.identifier = try container.decode(String.self, forKey: .identifier)

--- a/Sources/JsonModel/ResultData/ResultData.swift
+++ b/Sources/JsonModel/ResultData/ResultData.swift
@@ -46,7 +46,7 @@ import Foundation
 ///  JsonModel. This will allow us to divorce *our* code from SageResearch so that we can iterate
 ///  independently of third-party frameworks.
 ///
-public protocol ResultData : PolymorphicTyped, DictionaryRepresentable {
+public protocol ResultData : PolymorphicTyped, Encodable, DictionaryRepresentable {
     
     /// The identifier associated with the task, step, or asynchronous action.
     var identifier: String { get }
@@ -62,5 +62,11 @@ public protocol ResultData : PolymorphicTyped, DictionaryRepresentable {
     /// this allows results to either be structs *or* classes and allows collections of results to use
     /// mapping to deep copy their children.
     func deepCopy() -> Self
+}
+
+extension ResultData {
+    public func jsonDictionary() throws -> [String : JsonSerializable] {
+        try jsonEncodedDictionary()
+    }
 }
 

--- a/Sources/JsonModel/ResultData/ResultDataFactory.swift
+++ b/Sources/JsonModel/ResultData/ResultDataFactory.swift
@@ -38,12 +38,12 @@ import Foundation
 open class ResultDataFactory : SerializationFactory {
     
     public let resultSerializer = ResultDataSerializer()
-    public let answerCodingInfoSerializer = AnswerCodingInfoSerializer()
+    public let answerTypeSerializer = AnswerTypeSerializer()
     
     public required init() {
         super.init()
         self.registerSerializer(resultSerializer)
-        self.registerSerializer(answerCodingInfoSerializer)
+        self.registerSerializer(answerTypeSerializer)
     }
 }
 

--- a/Sources/JsonModel/ResultData/ResultDataSerializer.swift
+++ b/Sources/JsonModel/ResultData/ResultDataSerializer.swift
@@ -37,16 +37,12 @@ import Foundation
 /// `SerializableResultData` is the base implementation for `ResultData` that is serialized using
 /// the `Codable` protocol and the polymorphic serialization defined by this framework.
 ///
-public protocol SerializableResultData : ResultData, PolymorphicRepresentable, Encodable {
+public protocol SerializableResultData : ResultData, PolymorphicRepresentable {
     var serializableType: SerializableResultType { get }
 }
 
 extension SerializableResultData {
     public var typeName: String { serializableType.stringValue }
-    
-    public func jsonDictionary() throws -> [String : JsonSerializable] {
-        try jsonEncodedDictionary()
-    }
 }
 
 /// `serializableType` is an extendable string enum used by the `SerializationFactory` to

--- a/Sources/JsonModel/SerializationFactory.swift
+++ b/Sources/JsonModel/SerializationFactory.swift
@@ -1,7 +1,7 @@
 //
 //  SerializationFactory.swift
 //
-//  Copyright © 2017-2020 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2021 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -200,18 +200,18 @@ open class SerializationFactory : FactoryRegistration {
     
     /// `DateFormatter` to use for coding date-only strings. Default = `_ISO8601DateOnlyFormatter`.
     open var dateOnlyFormatter: DateFormatter {
-        return ISO8601DateOnlyFormatter
+        ISO8601DateOnlyFormatter
     }
     
     /// `DateFormatter` to use for coding time-only strings. Default = `_ISO8601TimeOnlyFormatter`.
     open var timeOnlyFormatter: DateFormatter {
-        return ISO8601TimeOnlyFormatter
+        ISO8601TimeOnlyFormatter
     }
     
     /// `DateFormatter` to use for coding timestamp strings that include both date and time components.
     /// Default = `_ISO8601TimestampFormatter`.
     open var timestampFormatter: DateFormatter {
-        return ISO8601TimestampFormatter
+        ISO8601TimestampFormatter
     }
     
     /// The default coding strategy to use for non-conforming elements.
@@ -382,7 +382,7 @@ extension FactoryDecoder {
     
     /// The factory to use when decoding.
     public var serializationFactory: SerializationFactory {
-        return self.userInfo[.factory] as? SerializationFactory ?? SerializationFactory.defaultFactory
+        self.userInfo[.factory] as? SerializationFactory ?? SerializationFactory.defaultFactory
     }
 }
 
@@ -392,22 +392,22 @@ extension Decoder {
     
     /// The factory to use when decoding.
     public var serializationFactory: SerializationFactory {
-        return self.userInfo[.factory] as? SerializationFactory ?? SerializationFactory.defaultFactory
+        self.userInfo[.factory] as? SerializationFactory ?? SerializationFactory.defaultFactory
     }
     
     /// The default bundle to use for embedded resources.
     public var bundle: ResourceBundle? {
-        return self.userInfo[.bundle] as? ResourceBundle
+        self.userInfo[.bundle] as? ResourceBundle
     }
     
     /// The default package to use for embedded resources.
     public var packageName: String? {
-        return self.userInfo[.packageName] as? String
+        self.userInfo[.packageName] as? String
     }
     
     /// The coding info object to use when decoding.
-    public var answerType: CodingInfo? {
-        return self.userInfo[.codingInfo] as? CodingInfo
+    public var codingInfo: CodingInfo? {
+        self.userInfo[.codingInfo] as? CodingInfo
     }
 }
 
@@ -430,12 +430,12 @@ extension Encoder {
     
     /// The factory to use when encoding.
     public var serializationFactory: SerializationFactory {
-        return self.userInfo[.factory] as? SerializationFactory ?? SerializationFactory.defaultFactory
+        self.userInfo[.factory] as? SerializationFactory ?? SerializationFactory.defaultFactory
     }
     
     /// The coding info object to use when encoding.
-    public var answerType: CodingInfo? {
-        return self.userInfo[.codingInfo] as? CodingInfo
+    public var codingInfo: CodingInfo? {
+        self.userInfo[.codingInfo] as? CodingInfo
     }
 }
 

--- a/Sources/JsonModel/SerializationFactory.swift
+++ b/Sources/JsonModel/SerializationFactory.swift
@@ -232,7 +232,7 @@ open class SerializationFactory : FactoryRegistration {
         decoder.userInfo[.factory] = self
         decoder.userInfo[.bundle] = resourceInfo?.factoryBundle
         decoder.userInfo[.packageName] = resourceInfo?.packageName
-        decoder.userInfo[.codingInfo] = CodingInfo()
+        decoder.userInfo[.answerType] = CodingInfo()
         decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: nonConformingCodingStrategy.positiveInfinity,
                                                                         negativeInfinity: nonConformingCodingStrategy.negativeInfinity,
                                                                         nan: nonConformingCodingStrategy.nan)
@@ -247,7 +247,7 @@ open class SerializationFactory : FactoryRegistration {
         decoder.userInfo[.factory] = self
         decoder.userInfo[.bundle] = resourceInfo?.factoryBundle
         decoder.userInfo[.packageName] = resourceInfo?.packageName
-        decoder.userInfo[.codingInfo] = CodingInfo()
+        decoder.userInfo[.answerType] = CodingInfo()
         return decoder
     }
     
@@ -316,7 +316,7 @@ open class SerializationFactory : FactoryRegistration {
         })
         encoder.outputFormatting = .prettyPrinted
         encoder.userInfo[.factory] = self
-        encoder.userInfo[.codingInfo] = CodingInfo()
+        encoder.userInfo[.answerType] = CodingInfo()
         encoder.nonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: nonConformingCodingStrategy.positiveInfinity,
                                                                         negativeInfinity: nonConformingCodingStrategy.negativeInfinity,
                                                                         nan: nonConformingCodingStrategy.nan)
@@ -333,7 +333,7 @@ open class SerializationFactory : FactoryRegistration {
     open func createPropertyListEncoder() -> PropertyListEncoder {
         let encoder = PropertyListEncoder()
         encoder.userInfo[.factory] = self
-        encoder.userInfo[.codingInfo] = CodingInfo()
+        encoder.userInfo[.answerType] = CodingInfo()
         return encoder
     }
     
@@ -362,7 +362,7 @@ extension CodingUserInfoKey {
     public static let packageName = CodingUserInfoKey(rawValue: "Factory.packageName")!
     
     /// The key for pointing to mutable coding info.
-    public static let codingInfo = CodingUserInfoKey(rawValue: "Factory.codingInfo")!
+    public static let answerType = CodingUserInfoKey(rawValue: "Factory.answerType")!
 }
 
 /// `JSONDecoder` and `PropertyListDecoder` do not share a common protocol so extend them to be
@@ -406,8 +406,8 @@ extension Decoder {
     }
     
     /// The coding info object to use when decoding.
-    public var codingInfo: CodingInfo? {
-        return self.userInfo[.codingInfo] as? CodingInfo
+    public var answerType: CodingInfo? {
+        return self.userInfo[.answerType] as? CodingInfo
     }
 }
 
@@ -434,8 +434,8 @@ extension Encoder {
     }
     
     /// The coding info object to use when encoding.
-    public var codingInfo: CodingInfo? {
-        return self.userInfo[.codingInfo] as? CodingInfo
+    public var answerType: CodingInfo? {
+        return self.userInfo[.answerType] as? CodingInfo
     }
 }
 

--- a/Sources/JsonModel/SerializationFactory.swift
+++ b/Sources/JsonModel/SerializationFactory.swift
@@ -198,18 +198,18 @@ open class SerializationFactory : FactoryRegistration {
         }
     }
     
-    /// `DateFormatter` to use for coding date-only strings. Default = `_ISO8601DateOnlyFormatter`.
+    /// `DateFormatter` to use for coding date-only strings. Default = `ISO8601DateOnlyFormatter`.
     open var dateOnlyFormatter: DateFormatter {
         ISO8601DateOnlyFormatter
     }
     
-    /// `DateFormatter` to use for coding time-only strings. Default = `_ISO8601TimeOnlyFormatter`.
+    /// `DateFormatter` to use for coding time-only strings. Default = `ISO8601TimeOnlyFormatter`.
     open var timeOnlyFormatter: DateFormatter {
         ISO8601TimeOnlyFormatter
     }
     
     /// `DateFormatter` to use for coding timestamp strings that include both date and time components.
-    /// Default = `_ISO8601TimestampFormatter`.
+    /// Default = `ISO8601TimestampFormatter`.
     open var timestampFormatter: DateFormatter {
         ISO8601TimestampFormatter
     }

--- a/Sources/JsonModel/SerializationFactory.swift
+++ b/Sources/JsonModel/SerializationFactory.swift
@@ -232,7 +232,7 @@ open class SerializationFactory : FactoryRegistration {
         decoder.userInfo[.factory] = self
         decoder.userInfo[.bundle] = resourceInfo?.factoryBundle
         decoder.userInfo[.packageName] = resourceInfo?.packageName
-        decoder.userInfo[.answerType] = CodingInfo()
+        decoder.userInfo[.codingInfo] = CodingInfo()
         decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: nonConformingCodingStrategy.positiveInfinity,
                                                                         negativeInfinity: nonConformingCodingStrategy.negativeInfinity,
                                                                         nan: nonConformingCodingStrategy.nan)
@@ -247,7 +247,7 @@ open class SerializationFactory : FactoryRegistration {
         decoder.userInfo[.factory] = self
         decoder.userInfo[.bundle] = resourceInfo?.factoryBundle
         decoder.userInfo[.packageName] = resourceInfo?.packageName
-        decoder.userInfo[.answerType] = CodingInfo()
+        decoder.userInfo[.codingInfo] = CodingInfo()
         return decoder
     }
     
@@ -316,7 +316,7 @@ open class SerializationFactory : FactoryRegistration {
         })
         encoder.outputFormatting = .prettyPrinted
         encoder.userInfo[.factory] = self
-        encoder.userInfo[.answerType] = CodingInfo()
+        encoder.userInfo[.codingInfo] = CodingInfo()
         encoder.nonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: nonConformingCodingStrategy.positiveInfinity,
                                                                         negativeInfinity: nonConformingCodingStrategy.negativeInfinity,
                                                                         nan: nonConformingCodingStrategy.nan)
@@ -333,7 +333,7 @@ open class SerializationFactory : FactoryRegistration {
     open func createPropertyListEncoder() -> PropertyListEncoder {
         let encoder = PropertyListEncoder()
         encoder.userInfo[.factory] = self
-        encoder.userInfo[.answerType] = CodingInfo()
+        encoder.userInfo[.codingInfo] = CodingInfo()
         return encoder
     }
     
@@ -362,7 +362,7 @@ extension CodingUserInfoKey {
     public static let packageName = CodingUserInfoKey(rawValue: "Factory.packageName")!
     
     /// The key for pointing to mutable coding info.
-    public static let answerType = CodingUserInfoKey(rawValue: "Factory.answerType")!
+    public static let codingInfo = CodingUserInfoKey(rawValue: "Factory.jsonAnswerType")!
 }
 
 /// `JSONDecoder` and `PropertyListDecoder` do not share a common protocol so extend them to be
@@ -407,7 +407,7 @@ extension Decoder {
     
     /// The coding info object to use when decoding.
     public var answerType: CodingInfo? {
-        return self.userInfo[.answerType] as? CodingInfo
+        return self.userInfo[.codingInfo] as? CodingInfo
     }
 }
 
@@ -435,7 +435,7 @@ extension Encoder {
     
     /// The coding info object to use when encoding.
     public var answerType: CodingInfo? {
-        return self.userInfo[.answerType] as? CodingInfo
+        return self.userInfo[.codingInfo] as? CodingInfo
     }
 }
 

--- a/Tests/JsonModelTests/AnswerCodingInfoTests.swift
+++ b/Tests/JsonModelTests/AnswerCodingInfoTests.swift
@@ -33,7 +33,7 @@
 import XCTest
 @testable import JsonModel
 
-class AnswerCodingInfoTests: XCTestCase {
+class AnswerTypeTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
@@ -47,14 +47,14 @@ class AnswerCodingInfoTests: XCTestCase {
         super.tearDown()
     }
 
-    func testAnswerCodingInfoString_Codable() {
+    func testAnswerTypeString_Codable() {
         do {
             let expectedObject = "hello"
             let expectedJson: JsonElement = .string("hello")
 
-            let AnswerCodingInfo = AnswerCodingInfoString()
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
-            let jsonValue = try AnswerCodingInfo.encodeAnswer(from: expectedObject)
+            let AnswerType = AnswerTypeString()
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
             
             XCTAssertEqual(objectValue as? String, expectedObject)
             XCTAssertEqual(jsonValue, expectedJson)
@@ -64,14 +64,14 @@ class AnswerCodingInfoTests: XCTestCase {
         }
     }
 
-    func testAnswerCodingInfoBoolean_Codable() {
+    func testAnswerTypeBoolean_Codable() {
          do {
             let expectedObject = true
             let expectedJson: JsonElement = .boolean(true)
             
-            let AnswerCodingInfo = AnswerCodingInfoBoolean()
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
-            let jsonValue = try AnswerCodingInfo.encodeAnswer(from: expectedObject)
+            let AnswerType = AnswerTypeBoolean()
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
             
             XCTAssertEqual(objectValue as? Bool, expectedObject)
             XCTAssertEqual(jsonValue, expectedJson)
@@ -81,14 +81,14 @@ class AnswerCodingInfoTests: XCTestCase {
         }
     }
 
-    func testAnswerCodingInfoInteger_Codable() {
+    func testAnswerTypeInteger_Codable() {
         do {
             let expectedObject = 12
             let expectedJson: JsonElement = .integer(12)
             
-            let AnswerCodingInfo = AnswerCodingInfoInteger()
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
-            let jsonValue = try AnswerCodingInfo.encodeAnswer(from: expectedObject)
+            let AnswerType = AnswerTypeInteger()
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
             
             XCTAssertEqual(objectValue as? Int, expectedObject)
             XCTAssertEqual(jsonValue, expectedJson)
@@ -98,14 +98,14 @@ class AnswerCodingInfoTests: XCTestCase {
         }
     }
 
-    func testAnswerCodingInfoNumber_Codable() {
+    func testAnswerTypeNumber_Codable() {
         do {
             let expectedObject = 12.5
             let expectedJson: JsonElement = .number(12.5)
             
-            let AnswerCodingInfo = AnswerCodingInfoNumber()
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
-            let jsonValue = try AnswerCodingInfo.encodeAnswer(from: expectedObject)
+            let AnswerType = AnswerTypeNumber()
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
             
             XCTAssertEqual(objectValue as? Double, expectedObject)
             XCTAssertEqual(jsonValue, expectedJson)
@@ -115,14 +115,14 @@ class AnswerCodingInfoTests: XCTestCase {
         }
     }
 
-    func testAnswerCodingInfoDateTime_Codable() {
+    func testAnswerTypeDateTime_Codable() {
 
         do {
             let expectedJson: JsonElement = .string("2016-02-20")
             
-            let AnswerCodingInfo = AnswerCodingInfoDateTime(codingFormat: "yyyy-MM-dd")
+            let AnswerType = AnswerTypeDateTime(codingFormat: "yyyy-MM-dd")
 
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
             if let date = objectValue as? Date {
                 let calendar = Calendar(identifier: .iso8601)
                 let calendarComponents: Set<Calendar.Component> = [.year, .month, .day]
@@ -131,7 +131,7 @@ class AnswerCodingInfoTests: XCTestCase {
                 XCTAssertEqual(comp.month, 2)
                 XCTAssertEqual(comp.day, 20)
                 
-                let jsonValue = try AnswerCodingInfo.encodeAnswer(from: date)
+                let jsonValue = try AnswerType.encodeAnswer(from: date)
                 XCTAssertEqual(expectedJson, jsonValue)
             }
             else {
@@ -143,14 +143,14 @@ class AnswerCodingInfoTests: XCTestCase {
         }
     }
 
-    func testAnswerCodingInfoArray_String_Codable() {
+    func testAnswerTypeArray_String_Codable() {
         do {
             let expectedObject = ["alpha", "beta", "gamma"]
             let expectedJson: JsonElement = .array(["alpha", "beta", "gamma"])
             
-            let AnswerCodingInfo = AnswerCodingInfoArray(baseType: .string)
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
-            let jsonValue = try AnswerCodingInfo.encodeAnswer(from: expectedObject)
+            let AnswerType = AnswerTypeArray(baseType: .string)
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
             
             XCTAssertEqual(objectValue as? [String], expectedObject)
             XCTAssertEqual(jsonValue, expectedJson)
@@ -160,14 +160,14 @@ class AnswerCodingInfoTests: XCTestCase {
         }
     }
 
-    func testAnswerCodingInfoArray_Integer_Codable() {
+    func testAnswerTypeArray_Integer_Codable() {
         do {
             let expectedObject = [65, 47, 99]
             let expectedJson: JsonElement = .array([65, 47, 99])
             
-            let AnswerCodingInfo = AnswerCodingInfoArray(baseType: .integer)
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
-            let jsonValue = try AnswerCodingInfo.encodeAnswer(from: expectedObject)
+            let AnswerType = AnswerTypeArray(baseType: .integer)
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
             
             XCTAssertEqual(objectValue as? [Int], expectedObject)
             XCTAssertEqual(jsonValue, expectedJson)
@@ -177,14 +177,14 @@ class AnswerCodingInfoTests: XCTestCase {
         }
     }
 
-    func testAnswerCodingInfoArray_Double_Codable() {
+    func testAnswerTypeArray_Double_Codable() {
         do {
             let expectedObject = [65.3, 47.2, 99.8]
             let expectedJson: JsonElement = .array([65.3, 47.2, 99.8])
             
-            let AnswerCodingInfo = AnswerCodingInfoArray(baseType: .number)
-            let objectValue = try AnswerCodingInfo.decodeAnswer(from: expectedJson)
-            let jsonValue = try AnswerCodingInfo.encodeAnswer(from: expectedObject)
+            let AnswerType = AnswerTypeArray(baseType: .number)
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
             
             XCTAssertEqual(objectValue as? [Double], expectedObject)
             XCTAssertEqual(jsonValue, expectedJson)

--- a/Tests/JsonModelTests/AnswerResultObjectTests.swift
+++ b/Tests/JsonModelTests/AnswerResultObjectTests.swift
@@ -70,7 +70,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.codingInfo is AnswerCodingInfoString, "\(String(describing: object.codingInfo))")
+            XCTAssertTrue(object.answerType is AnswerTypeString, "\(String(describing: object.answerType))")
             XCTAssertNil(object.jsonValue)
             
             let jsonData = try encoder.encode(object)
@@ -109,7 +109,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.codingInfo is AnswerCodingInfoString, "\(String(describing: object.codingInfo))")
+            XCTAssertTrue(object.answerType is AnswerTypeString, "\(String(describing: object.answerType))")
             XCTAssertEqual(object.jsonValue, .string("hello"))
             
             let jsonData = try encoder.encode(object)
@@ -155,7 +155,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.codingInfo is AnswerCodingInfoBoolean, "\(String(describing: object.codingInfo))")
+            XCTAssertTrue(object.answerType is AnswerTypeBoolean, "\(String(describing: object.answerType))")
             XCTAssertEqual(object.jsonValue, .boolean(true))
             
             let jsonData = try encoder.encode(object)
@@ -201,7 +201,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.codingInfo is AnswerCodingInfoInteger, "\(String(describing: object.codingInfo))")
+            XCTAssertTrue(object.answerType is AnswerTypeInteger, "\(String(describing: object.answerType))")
             XCTAssertEqual(object.jsonValue, .integer(12))
             
             let jsonData = try encoder.encode(object)
@@ -247,7 +247,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.codingInfo is AnswerCodingInfoNumber, "\(String(describing: object.codingInfo))")
+            XCTAssertTrue(object.answerType is AnswerTypeNumber, "\(String(describing: object.answerType))")
             XCTAssertEqual(object.jsonValue, .number(12.5))
             
             let jsonData = try encoder.encode(object)
@@ -294,11 +294,11 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            if let answerType = object.codingInfo as? AnswerCodingInfoDateTime {
+            if let answerType = object.answerType as? AnswerTypeDateTime {
                 XCTAssertEqual(answerType.codingFormat, "yyyy-MM-dd")
             }
             else {
-                XCTFail("Failed to decode answerType as a AnswerCodingInfoDateTime")
+                XCTFail("Failed to decode answerType as a AnswerTypeDateTime")
             }
             XCTAssertEqual(object.jsonValue, .string("2016-02-20"))
             
@@ -347,11 +347,11 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            if let answerType = object.codingInfo as? AnswerCodingInfoArray {
+            if let answerType = object.answerType as? AnswerTypeArray {
                 XCTAssertEqual(answerType.baseType, .integer)
             }
             else {
-                XCTFail("Failed to decode \(String(describing: object.codingInfo)) as a AnswerCodingInfoArray")
+                XCTFail("Failed to decode \(String(describing: object.answerType)) as a AnswerTypeArray")
             }
             XCTAssertEqual(object.jsonValue, .array([1, 3, 5]))
             
@@ -405,12 +405,12 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            if let answerType = object.codingInfo as? AnswerCodingInfoArray {
+            if let answerType = object.answerType as? AnswerTypeArray {
                 XCTAssertEqual(answerType.baseType, .integer)
                 XCTAssertEqual(answerType.sequenceSeparator, "-")
             }
             else {
-                XCTFail("Failed to decode answerType as a AnswerCodingInfoDateTime")
+                XCTFail("Failed to decode answerType as a AnswerTypeDateTime")
             }
             XCTAssertEqual(object.jsonValue, .array([206, 555, 1212]))
             
@@ -460,7 +460,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            XCTAssertTrue(object.codingInfo is AnswerCodingInfoObject, "\(String(describing: object.codingInfo))")
+            XCTAssertTrue(object.answerType is AnswerTypeObject, "\(String(describing: object.answerType))")
             XCTAssertEqual(object.jsonValue, .object(["breakfast": "08:20", "lunch": "12:40", "dinner": "19:10"]))
             
             let jsonData = try encoder.encode(object)

--- a/Tests/JsonModelTests/AnswerResultObjectTests.swift
+++ b/Tests/JsonModelTests/AnswerResultObjectTests.swift
@@ -70,7 +70,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.answerType is AnswerTypeString, "\(String(describing: object.answerType))")
+            XCTAssertTrue(object.jsonAnswerType is AnswerTypeString, "\(String(describing: object.jsonAnswerType))")
             XCTAssertNil(object.jsonValue)
             
             let jsonData = try encoder.encode(object)
@@ -109,7 +109,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.answerType is AnswerTypeString, "\(String(describing: object.answerType))")
+            XCTAssertTrue(object.jsonAnswerType is AnswerTypeString, "\(String(describing: object.jsonAnswerType))")
             XCTAssertEqual(object.jsonValue, .string("hello"))
             
             let jsonData = try encoder.encode(object)
@@ -155,7 +155,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.answerType is AnswerTypeBoolean, "\(String(describing: object.answerType))")
+            XCTAssertTrue(object.jsonAnswerType is AnswerTypeBoolean, "\(String(describing: object.jsonAnswerType))")
             XCTAssertEqual(object.jsonValue, .boolean(true))
             
             let jsonData = try encoder.encode(object)
@@ -201,7 +201,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.answerType is AnswerTypeInteger, "\(String(describing: object.answerType))")
+            XCTAssertTrue(object.jsonAnswerType is AnswerTypeInteger, "\(String(describing: object.jsonAnswerType))")
             XCTAssertEqual(object.jsonValue, .integer(12))
             
             let jsonData = try encoder.encode(object)
@@ -247,7 +247,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
-            XCTAssertTrue(object.answerType is AnswerTypeNumber, "\(String(describing: object.answerType))")
+            XCTAssertTrue(object.jsonAnswerType is AnswerTypeNumber, "\(String(describing: object.jsonAnswerType))")
             XCTAssertEqual(object.jsonValue, .number(12.5))
             
             let jsonData = try encoder.encode(object)
@@ -294,7 +294,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            if let answerType = object.answerType as? AnswerTypeDateTime {
+            if let answerType = object.jsonAnswerType as? AnswerTypeDateTime {
                 XCTAssertEqual(answerType.codingFormat, "yyyy-MM-dd")
             }
             else {
@@ -347,11 +347,11 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            if let answerType = object.answerType as? AnswerTypeArray {
+            if let answerType = object.jsonAnswerType as? AnswerTypeArray {
                 XCTAssertEqual(answerType.baseType, .integer)
             }
             else {
-                XCTFail("Failed to decode \(String(describing: object.answerType)) as a AnswerTypeArray")
+                XCTFail("Failed to decode \(String(describing: object.jsonAnswerType)) as a AnswerTypeArray")
             }
             XCTAssertEqual(object.jsonValue, .array([1, 3, 5]))
             
@@ -405,7 +405,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            if let answerType = object.answerType as? AnswerTypeArray {
+            if let answerType = object.jsonAnswerType as? AnswerTypeArray {
                 XCTAssertEqual(answerType.baseType, .integer)
                 XCTAssertEqual(answerType.sequenceSeparator, "-")
             }
@@ -460,7 +460,7 @@ class AnswerResultObjectTests: XCTestCase {
             XCTAssertEqual(object.typeName, "answer")
             XCTAssertGreaterThan(object.endDate, object.startDate)
             
-            XCTAssertTrue(object.answerType is AnswerTypeObject, "\(String(describing: object.answerType))")
+            XCTAssertTrue(object.jsonAnswerType is AnswerTypeObject, "\(String(describing: object.jsonAnswerType))")
             XCTAssertEqual(object.jsonValue, .object(["breakfast": "08:20", "lunch": "12:40", "dinner": "19:10"]))
             
             let jsonData = try encoder.encode(object)

--- a/Tests/JsonModelTests/ResultDataTests.swift
+++ b/Tests/JsonModelTests/ResultDataTests.swift
@@ -98,8 +98,8 @@ class ResultDataTests: XCTestCase {
             
             if let result1 = object.children.first as? AnswerResultObject {
                 XCTAssertEqual(result1.identifier, answerResult1.identifier)
-                let expected = AnswerCodingInfoBoolean()
-                XCTAssertEqual(expected, answerResult1.codingInfo as? AnswerCodingInfoBoolean)
+                let expected = AnswerTypeBoolean()
+                XCTAssertEqual(expected, answerResult1.answerType as? AnswerTypeBoolean)
                 XCTAssertEqual(result1.startDate.timeIntervalSinceNow, answerResult1.startDate.timeIntervalSinceNow, accuracy: 1)
                 XCTAssertEqual(result1.endDate.timeIntervalSinceNow, answerResult1.endDate.timeIntervalSinceNow, accuracy: 1)
                 XCTAssertEqual(result1.jsonValue, answerResult1.jsonValue)
@@ -177,7 +177,7 @@ class ResultDataTests: XCTestCase {
     
     func testAnswerResultObject_Copy() {
         let result = AnswerResultObject(identifier: "foo",
-                                        codingInfo: AnswerCodingInfoMeasurement(unit: "cm"),
+                                        answerType: AnswerTypeMeasurement(unit: "cm"),
                                         value: .number(42),
                                         questionText: "What is your favorite color?",
                                         questionData: .boolean(true))
@@ -190,7 +190,7 @@ class ResultDataTests: XCTestCase {
         XCTAssertEqual(result.jsonValue, copy.jsonValue)
         XCTAssertEqual(result.questionText, copy.questionText)
         XCTAssertEqual(result.questionData, copy.questionData)
-        XCTAssertEqual("cm", (copy.codingInfo as? AnswerCodingInfoMeasurement)?.unit)
+        XCTAssertEqual("cm", (copy.answerType as? AnswerTypeMeasurement)?.unit)
     }
     
     func testSerializers() {
@@ -198,8 +198,8 @@ class ResultDataTests: XCTestCase {
         
         XCTAssertTrue(checkPolymorphicExamples(for: factory.resultSerializer.examples,
                                                 using: factory, protocolType: ResultData.self))
-        XCTAssertTrue(checkPolymorphicExamples(for: factory.answerCodingInfoSerializer.examples,
-                                                using: factory, protocolType: AnswerCodingInfo.self))
+        XCTAssertTrue(checkPolymorphicExamples(for: factory.answerTypeSerializer.examples,
+                                                using: factory, protocolType: AnswerType.self))
 
     }
     

--- a/Tests/JsonModelTests/ResultDataTests.swift
+++ b/Tests/JsonModelTests/ResultDataTests.swift
@@ -99,7 +99,7 @@ class ResultDataTests: XCTestCase {
             if let result1 = object.children.first as? AnswerResultObject {
                 XCTAssertEqual(result1.identifier, answerResult1.identifier)
                 let expected = AnswerTypeBoolean()
-                XCTAssertEqual(expected, answerResult1.answerType as? AnswerTypeBoolean)
+                XCTAssertEqual(expected, answerResult1.jsonAnswerType as? AnswerTypeBoolean)
                 XCTAssertEqual(result1.startDate.timeIntervalSinceNow, answerResult1.startDate.timeIntervalSinceNow, accuracy: 1)
                 XCTAssertEqual(result1.endDate.timeIntervalSinceNow, answerResult1.endDate.timeIntervalSinceNow, accuracy: 1)
                 XCTAssertEqual(result1.jsonValue, answerResult1.jsonValue)
@@ -190,7 +190,7 @@ class ResultDataTests: XCTestCase {
         XCTAssertEqual(result.jsonValue, copy.jsonValue)
         XCTAssertEqual(result.questionText, copy.questionText)
         XCTAssertEqual(result.questionData, copy.questionData)
-        XCTAssertEqual("cm", (copy.answerType as? AnswerTypeMeasurement)?.unit)
+        XCTAssertEqual("cm", (copy.jsonAnswerType as? AnswerTypeMeasurement)?.unit)
     }
     
     func testSerializers() {


### PR DESCRIPTION
At this point I have tested out migrating all our internal projects to reference the `ResultData` protocol *instead* of `RSDResult` so that the mobile passive data can be agnostic to SageResearch. I also reverted back to using "AnswerType" as the naming convention rather than "AnswerCodingInfo" because there were just too many changes needed to support that migration.