### PR TITLE
Patch 1.1.1

### DIFF
--- a/Sources/JsonModel/PolymorphicSerializer.swift
+++ b/Sources/JsonModel/PolymorphicSerializer.swift
@@ -58,7 +58,7 @@ public protocol PolymorphicTyped {
 /// The generic method for a decodable. This is a work-around for the limitations of Swift generics
 /// where an instance of a class that has an associated type cannot be stored in a dictionary or
 /// array.
-public protocol GenericSerializer : class, DocumentableInterface {
+public protocol GenericSerializer : AnyObject, DocumentableInterface {
     var interfaceName : String { get }
     func decode(from decoder: Decoder) throws -> Any
     func documentableExamples() -> [DocumentableObject]

--- a/Sources/JsonModel/ResourceInfo.swift
+++ b/Sources/JsonModel/ResourceInfo.swift
@@ -58,7 +58,7 @@ public protocol ResourceInfo {
 /// A resource bundle is used on Apple platforms to point to the `Bundle` for the resource. It is
 /// not directly referenced within this framework to avoid any Apple-specific resource handling
 /// classes and to allow for testing.
-public protocol ResourceBundle : class {
+public protocol ResourceBundle : AnyObject {
     
     /// The identifier of the bundle within which the resource is embedded on Apple platforms.
     var bundleIdentifier: String? { get }

--- a/Sources/JsonModel/SerializationFactory.swift
+++ b/Sources/JsonModel/SerializationFactory.swift
@@ -128,13 +128,20 @@ open class SerializationFactory : FactoryRegistration {
         }()
         if let obj = decodedObject as? DecodableBundleInfo {
             var resource = obj
-            resource.factoryBundle = decoder.bundle
+            resource.factoryBundle = self.resourceBundle(for: obj, from: decoder)
             resource.packageName = decoder.packageName
             return resource as! T
         }
         else {
             return decodedObject
         }
+    }
+    
+    /// By default, it is assumed that a single resource bundle will be used for all resources used by a module.
+    /// However, this allows a factory subclass to inspect the bundle info and return a different resource bundle
+    /// if need be.
+    open func resourceBundle(for bundleInfo: DecodableBundleInfo, from decoder: Decoder) -> ResourceBundle? {
+        decoder.bundle
     }
     
     /// If required, allow the factory to set up pointers or transform the decoded objects.

--- a/Sources/JsonModel/SerializationFactory.swift
+++ b/Sources/JsonModel/SerializationFactory.swift
@@ -32,7 +32,7 @@
 
 import Foundation
 
-public protocol FactoryRegistration : class {
+public protocol FactoryRegistration : AnyObject {
     init()
     func isRegistered<T>(for type: T.Type, with typeName: String) -> Bool
 }


### PR DESCRIPTION
MTB uses a different repo for *some* of the resources that are shared with their Android implementation. This would allow those resources to be loaded as a separate bundle using SwiftPM.