### PR TITLE
Add answer types

### DIFF
--- a/Sources/JsonModel/Documentable.swift
+++ b/Sources/JsonModel/Documentable.swift
@@ -78,6 +78,10 @@ extension StringEnumSet {
     public var indexPosition: Int {
         type(of: self).allValues().firstIndex(of: self.stringValue)!
     }
+    
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.indexPosition < rhs.indexPosition
+    }
 }
 
 public protocol DocumentableStringLiteral : DocumentableString {

--- a/Sources/JsonModel/ResultData/AnswerType.swift
+++ b/Sources/JsonModel/ResultData/AnswerType.swift
@@ -649,17 +649,22 @@ public struct AnswerTypeDuration : DecimalAnswerType, Codable, Hashable {
     public private(set) var serializableType: AnswerTypeType = Self.defaultType
     
     /// The units used to build the question for the participant.
-    public let displayUnits: [String]?
+    public let displayUnits: [DurationUnit]?
     
     /// The number of significant digits for the value in seconds.
     public let significantDigits: Int?
     
-    public init(significantDigits: Int = 0, displayUnits: [String] = ["H","M"]) {
+    public init(significantDigits: Int = 0, displayUnits: [DurationUnit] = DurationUnit.defaultDispayUnits) {
         self.displayUnits = displayUnits
         self.significantDigits = significantDigits
     }
 }
 extension AnswerTypeDuration : NumberJsonType {
+}
+
+public enum DurationUnit : String, StringEnumSet, DocumentableStringEnum {
+    case hour, minute, second
+    public static let defaultDispayUnits: [DurationUnit] = [.hour, .minute]
 }
 
 public struct AnswerTypeMeasurement : DecimalAnswerType, Codable, Hashable {
@@ -917,8 +922,8 @@ extension AnswerTypeDuration : AnswerTypeDocumentable, DocumentableStruct {
         case .serializableType:
             return .init(constValue: defaultType)
         case .displayUnits:
-            return .init(propertyType: .primitiveArray(.string), propertyDescription:
-                            "The units used to display the duration as a question. These are the ISO8601 duration units in sequence.")
+            return .init(propertyType: .referenceArray(DurationUnit.documentableType()), propertyDescription:
+                            "The units used to display the duration as a question.")
         case .significantDigits:
             return .init(propertyType: .primitive(.number), propertyDescription:
                             "The number of significant digits to use in encoding the answer.")

--- a/Tests/JsonModelTests/ResultDataTests/AnswerCodingInfoTests.swift
+++ b/Tests/JsonModelTests/ResultDataTests/AnswerCodingInfoTests.swift
@@ -118,6 +118,23 @@ class AnswerTypeTests: XCTestCase {
             XCTFail("Failed to decode/encode object: \(err)")
         }
     }
+    
+    func testAnswerTypeDuration_Codable() {
+        do {
+            let expectedObject = 12.5
+            let expectedJson: JsonElement = .number(12.5)
+            
+            let AnswerType = AnswerTypeNumber()
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            let jsonValue = try AnswerType.encodeAnswer(from: expectedObject)
+            
+            XCTAssertEqual(objectValue as? Double, expectedObject)
+            XCTAssertEqual(jsonValue, expectedJson)
+            
+        } catch let err {
+            XCTFail("Failed to decode/encode object: \(err)")
+        }
+    }
 
     func testAnswerTypeDateTime_Codable() {
 
@@ -134,6 +151,33 @@ class AnswerTypeTests: XCTestCase {
                 XCTAssertEqual(comp.year, 2016)
                 XCTAssertEqual(comp.month, 2)
                 XCTAssertEqual(comp.day, 20)
+                
+                let jsonValue = try AnswerType.encodeAnswer(from: date)
+                XCTAssertEqual(expectedJson, jsonValue)
+            }
+            else {
+                XCTFail("Failed to decode String to a Date: \(String(describing: objectValue))")
+            }
+            
+        } catch let err {
+            XCTFail("Failed to decode/encode object: \(err)")
+        }
+    }
+    
+    func testAnswerTypeTime_Codable() {
+
+        do {
+            let expectedJson: JsonElement = .string("22:32:00.000")
+            
+            let AnswerType = AnswerTypeTime()
+
+            let objectValue = try AnswerType.decodeAnswer(from: expectedJson)
+            if let date = objectValue as? Date {
+                let calendar = Calendar(identifier: .iso8601)
+                let calendarComponents: Set<Calendar.Component> = [.hour, .minute]
+                let comp = calendar.dateComponents(calendarComponents, from: date)
+                XCTAssertEqual(comp.hour, 22)
+                XCTAssertEqual(comp.minute, 32)
                 
                 let jsonValue = try AnswerType.encodeAnswer(from: date)
                 XCTAssertEqual(expectedJson, jsonValue)
@@ -202,7 +246,7 @@ class AnswerTypeTests: XCTestCase {
         // Check that an example of all the standard results are included in the serializer.
         let serializer = AnswerTypeSerializer()
         let actual = Set(serializer.examples.map { $0.typeName })
-        var expected = Set(["measurement", "date-time"]).union(JsonType.allCases.map { $0.rawValue })
+        var expected = Set(["measurement", "date-time", "time", "duration"]).union(JsonType.allCases.map { $0.rawValue })
         expected.remove("null")
         XCTAssertEqual(expected.count, actual.count)
         XCTAssertEqual(expected, actual)


### PR DESCRIPTION
Because SageResearch doesn't inherit from AssessmentModel, the results are added to JsonModel instead.