### PR TITLE
Any inheritance (including interfaces) must be open

### DIFF
--- a/Sources/JsonModel/Documentable.swift
+++ b/Sources/JsonModel/Documentable.swift
@@ -529,7 +529,7 @@ public class JsonDocumentBuilder {
             return JsonSchema(id: URL(string: rootPointer.refId.classPath)!,
                               description: rootPointer.documentDescription ?? "",
                               isArray: rootPointer.isArray,
-                              isOpen: isOpen,
+                              additionalProperties: (isOpen || interfaces.count > 0) ? nil : false,
                               codingKeys: docType.codingKeys(),
                               interfaces: interfaces.count > 0 ? interfaces : nil,
                               definitions: definitions,
@@ -792,7 +792,7 @@ public class JsonDocumentBuilder {
                     return JsonSchemaObjectRef(ref: refId)
                 }
                 return .object(JsonSchemaObject(id: ref,
-                                                isOpen: docType.isOpen(),
+                                                additionalProperties: (docType.isOpen() || interfaces.count > 0) ? nil : false,
                                                 description: "",
                                                 codingKeys: docType.codingKeys(),
                                                 properties: properties,

--- a/Tests/JsonModelTests/DocumentableTests.swift
+++ b/Tests/JsonModelTests/DocumentableTests.swift
@@ -100,7 +100,7 @@ final class DocumentableTests: XCTestCase {
         XCTAssertEqual("Sample", jsonSchema.root.title)
         XCTAssertEqual("Sample is an example interface used for unit testing.", jsonSchema.root.description)
         
-        XCTAssertTrue(jsonSchema.root.isOpen)
+        XCTAssertNil(jsonSchema.root.additionalProperties)
         XCTAssertNil(jsonSchema.root.allOf)
         XCTAssertNil(jsonSchema.root.examples)
         XCTAssertNotNil(jsonSchema.definitions)
@@ -155,7 +155,7 @@ final class DocumentableTests: XCTestCase {
             XCTAssertEqual(key, obj.title)
             XCTAssertEqual(obj.allOf?.map { $0.ref }, ["#"])
             XCTAssertEqual(Set(obj.required ?? []), ["type","value"])
-            XCTAssertFalse(obj.isOpen)
+            XCTAssertNil(obj.additionalProperties)
             let expectedExamples = [
                 AnyCodableDictionary(["type":"a","value":3]),
                 AnyCodableDictionary(["type":"a","value":2,"color":"yellow","animalMap": ["blue":["robin","sparrow"]]])
@@ -179,7 +179,7 @@ final class DocumentableTests: XCTestCase {
             XCTAssertEqual(key, obj.title)
             XCTAssertEqual(obj.allOf?.map { $0.ref }, ["#"])
             XCTAssertEqual(Set(obj.required ?? []), ["type","value"])
-            XCTAssertFalse(obj.isOpen)
+            XCTAssertNil(obj.additionalProperties)
             
             let sampleItemRef = JsonSchemaReferenceId("SampleItem", isExternal: externalSampleItem)
             

--- a/Tests/JsonModelTests/JsonSchemaTests.swift
+++ b/Tests/JsonModelTests/JsonSchemaTests.swift
@@ -455,7 +455,6 @@ final class JsonSchemaTests: XCTestCase {
                     }
                 }
             },
-            "additionalProperties": false,
             "required": ["type", "identifier"],
             "allOf": [{ "$ref": "#Goo" }],
             "examples": [{
@@ -470,7 +469,6 @@ final class JsonSchemaTests: XCTestCase {
             .init(stringValue: $0.element, intValue: $0.offset)
         }
         let original = JsonSchemaObject(id: JsonSchemaReferenceId("Foo"),
-                                        isOpen: false,
                                         description: "This is an example of a polymorphic object",
                                         codingKeys: codingKeys,
                                         properties: [
@@ -576,7 +574,7 @@ final class JsonSchemaTests: XCTestCase {
         }
         """.data(using: .utf8)! // our data in native (JSON) format
 
-        let origObjectDef: JsonSchemaDefinition = .object(JsonSchemaObject(id: JsonSchemaReferenceId("Baloo"), properties: ["value": .primitive(.string)]))
+        let origObjectDef: JsonSchemaDefinition = .object(JsonSchemaObject(id: JsonSchemaReferenceId("Baloo"), additionalProperties: false, properties: ["value": .primitive(.string)]))
         let origDefinitions: [JsonSchemaDefinition] = [
             origObjectDef,
             .stringLiteral(JsonSchemaStringLiteral(id: JsonSchemaReferenceId("GooType"))),
@@ -588,7 +586,6 @@ final class JsonSchemaTests: XCTestCase {
         let original = JsonSchema(id: URL(string: "http://sagebionetworks.org/Foo.json")!,
                                   description: "This is an example of a polymorphic object",
                                   isArray: false,
-                                  isOpen: true,
                                   codingKeys: codingKeys,
                                   interfaces: [.init(ref: JsonSchemaReferenceId("Goo")),
                                                .init(ref: JsonSchemaReferenceId("Moo", isExternal: true))],
@@ -626,7 +623,7 @@ final class JsonSchemaTests: XCTestCase {
             XCTAssertEqual(original.root.properties, decodedObject.root.properties)
             XCTAssertEqual(original.root.required, decodedObject.root.required)
             XCTAssertEqual(original.root.examples, decodedObject.root.examples)
-            XCTAssertEqual(original.root.isOpen, decodedObject.root.isOpen)
+            XCTAssertEqual(original.root.additionalProperties, decodedObject.root.additionalProperties)
             
             origDefinitions.forEach { definition in
                 guard let className = definition.className else {
@@ -647,7 +644,7 @@ final class JsonSchemaTests: XCTestCase {
                         XCTAssertEqual(objDef.id, decodedObjDef.id)
                         XCTAssertEqual(objDef.required, decodedObjDef.required)
                         XCTAssertEqual(objDef.allOf, decodedObjDef.allOf)
-                        XCTAssertEqual(objDef.isOpen, decodedObjDef.isOpen)
+                        XCTAssertEqual(objDef.additionalProperties, decodedObjDef.additionalProperties)
                         XCTAssertEqual(objDef.examples, decodedObjDef.examples)
                     }
                     else {
@@ -749,7 +746,7 @@ final class JsonSchemaTests: XCTestCase {
         """.data(using: .utf8)! // our data in native (JSON) format
 
         let origDefinitions: [JsonSchemaDefinition] = [
-            .object(JsonSchemaObject(id: JsonSchemaReferenceId("Baloo"), isOpen: false, properties: ["value": .primitive(.string)])),
+            .object(JsonSchemaObject(id: JsonSchemaReferenceId("Baloo"), additionalProperties: false, properties: ["value": .primitive(.string)])),
             .stringLiteral(JsonSchemaStringLiteral(id: JsonSchemaReferenceId("GooType"))),
             .stringEnum(JsonSchemaStringEnum(id: JsonSchemaReferenceId("RuType"), values: ["moo", "loo", "twentyToo"]))]
 
@@ -760,7 +757,6 @@ final class JsonSchemaTests: XCTestCase {
         let original = JsonSchema(id: URL(string: "http://sagebionetworks.org/Foo.json")!,
                                   description: "This is an example of a polymorphic object",
                                   isArray: true,
-                                  isOpen: true,
                                   codingKeys: codingKeys,
                                   interfaces: [.init(ref: JsonSchemaReferenceId("Goo")),
                                                .init(ref: JsonSchemaReferenceId("Moo", isExternal: true))],
@@ -797,7 +793,7 @@ final class JsonSchemaTests: XCTestCase {
             XCTAssertEqual(original.root.properties, decodedObject.root.properties)
             XCTAssertEqual(original.root.required, decodedObject.root.required)
             XCTAssertEqual(original.root.examples, decodedObject.root.examples)
-            XCTAssertEqual(original.root.isOpen, decodedObject.root.isOpen)
+            XCTAssertEqual(original.root.additionalProperties, decodedObject.root.additionalProperties)
             
             origDefinitions.forEach { definition in
                 guard let className = definition.className else {


### PR DESCRIPTION
Json Schema Draft 7 defines `additionalProperties` and `allOf` as mutually exclusive. In other words, an interface or protocol is considered “inheritance” and classes cannot be defined as final.