### PR TITLE
Fix encoding of `JsonElement.null` for an array

### DIFF
--- a/Sources/JsonModel/ResultData/AnswerResult.swift
+++ b/Sources/JsonModel/ResultData/AnswerResult.swift
@@ -73,7 +73,8 @@ public extension AnswerResult {
     /// encoding strategy desired by the researchers who are using it in their studies, while keeping the
     /// model generic and reusable for the developers.
     func encodingValue() throws -> JsonElement? {
-        try self.jsonAnswerType?.encodeAnswer(from: self.jsonValue) ?? self.jsonValue
+        let val = try self.jsonAnswerType?.encodeAnswer(from: self.jsonValue) ?? self.jsonValue
+        return val.flatMap { $0 == .null ? nil : $0 }
     }
 }
 

--- a/Tests/JsonModelTests/ResultDataTests/AnswerResultObjectTests.swift
+++ b/Tests/JsonModelTests/ResultDataTests/AnswerResultObjectTests.swift
@@ -384,6 +384,59 @@ class AnswerResultObjectTests: XCTestCase {
             XCTFail("Failed to decode/encode object: \(err)")
         }
     }
+    
+    func testAnswerResultObject_StringArray_NullValue() {
+        let json = """
+        {
+            "type":"answer",
+            "identifier":"foo",
+            "startDate":"2017-10-16T22:28:09.000-02:30",
+            "answerType":{"type":"array","baseType":"string"},
+            "value":null
+        }
+        """.data(using: .utf8)! // our data in native (JSON) format
+        
+        do {
+            
+            let object = try decoder.decode(AnswerResultObject.self, from: json)
+            
+            XCTAssertEqual(object.identifier, "foo")
+            XCTAssertEqual(object.typeName, "answer")
+            XCTAssertNil(object.endDateTime)
+            
+            if let answerType = object.jsonAnswerType as? AnswerTypeArray {
+                XCTAssertEqual(answerType.baseType, .string)
+            }
+            else {
+                XCTFail("Failed to decode \(String(describing: object.jsonAnswerType)) as a AnswerTypeArray")
+            }
+            XCTAssertEqual(object.jsonValue, .null)
+            
+            let jsonData = try encoder.encode(object)
+            guard let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String : Any]
+                else {
+                    XCTFail("Encoded object is not a dictionary")
+                    return
+            }
+            
+            XCTAssertEqual(dictionary["identifier"] as? String, "foo")
+            XCTAssertEqual(dictionary["type"] as? String, "answer")
+            XCTAssertEqual(dictionary["startDate"] as? String, "2017-10-16T22:28:09.000-02:30")
+            XCTAssertNil(dictionary["endDate"])
+            XCTAssertNil(dictionary["value"])
+            
+            if let answerType = dictionary["answerType"] as? [String:Any] {
+                XCTAssertEqual(answerType["type"] as? String, "array")
+                XCTAssertEqual(answerType["baseType"] as? String, "string")
+            }
+            else {
+                XCTFail("Encoded object does not include the answerType")
+            }
+            
+        } catch let err {
+            XCTFail("Failed to decode/encode object: \(err)")
+        }
+    }
 
     func testAnswerResultObject_IntegerArray_StringSeparator_Codable() {
         let json = """


### PR DESCRIPTION
A .null JsonElement is used in survey navigation to mark a question as “not answered” (skipped or still shown)
and that was not being encoded properly for an array.