### PR TITLE
Polymorphic serialization - property wrappers and additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Moved the results protocols and objects into a separate target within the JsonMo
 library. To migrate to this version, you will need to `import ResultModel` anywhere
 that you reference `ResultData` model objects.
 
+### Version 2.1
+
+- Added property wrappers that can be used in polymorphic serialization.
+- Deprecated `PolymorphicSerializer` and replaced with `GenericPolymorphicSerializer`
+
 ## License
 
 JsonModel is available under the BSD license:

--- a/Sources/JsonModel/IdentifiableInterfaceSerializer.swift
+++ b/Sources/JsonModel/IdentifiableInterfaceSerializer.swift
@@ -6,6 +6,7 @@
 import Foundation
 
 /// Convenience implementation for a serializer that includes a required `identifier` key.
+@available(*, deprecated, message: "Use `GenericPolymorphicSerializer` instead.")
 open class IdentifiableInterfaceSerializer : AbstractPolymorphicSerializer {
     private enum InterfaceKeys : String, OpenOrderedCodingKey {
         case identifier
@@ -30,3 +31,4 @@ open class IdentifiableInterfaceSerializer : AbstractPolymorphicSerializer {
         }
     }
 }
+

--- a/Sources/JsonModel/OrderedJSONEncoder.swift
+++ b/Sources/JsonModel/OrderedJSONEncoder.swift
@@ -31,27 +31,21 @@ public protocol OpenOrderedCodingKey : OrderedCodingKey {
 /// `OrderedCodingKey` protocol.
 open class OrderedJSONEncoder : JSONEncoder {
     
-    public override init() {
-        self._keyEncodingStrategy = .custom({ codingPath in
-            return IndexedCodingKey(key: codingPath.last!) ?? codingPath.last!
-        })
-        super.init()
-    }
-    
-    /// Should the encoded data be sorted to order the keys for coding keys that implement the `OrderedCodingKey` protocol?
-    /// By default, keys are *not* ordered so that encoding will run faster, but they can be if the protocol supports doing so.
-    public var shouldOrderKeys: Bool = false
-    
-    override open var keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy {
-        get {
-            shouldOrderKeys ? _keyEncodingStrategy : super.keyEncodingStrategy
-        }
-        set {
-            super.keyEncodingStrategy = newValue
-            shouldOrderKeys = false
+    /// Should the encoded data be sorted to order the keys for coding keys that implement the
+    /// `OrderedCodingKey` protocol? By default, keys are *not* ordered so that encoding will
+    /// run faster, but they can be if the protocol supports doing so.
+    public var shouldOrderKeys: Bool = false {
+        didSet {
+            if shouldOrderKeys {
+                self.keyEncodingStrategy = .custom({ codingPath in
+                    return IndexedCodingKey(key: codingPath.last!) ?? codingPath.last!
+                })
+            }
+            else {
+                self.keyEncodingStrategy = .useDefaultKeys
+            }
         }
     }
-    private var _keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
     
     override open var outputFormatting: JSONEncoder.OutputFormatting {
         get {

--- a/Sources/JsonModel/PolymorphicSerializer.swift
+++ b/Sources/JsonModel/PolymorphicSerializer.swift
@@ -96,14 +96,19 @@ open class GenericPolymorphicSerializer<ProtocolValue> : GenericSerializer {
     }
     private var _examples: [String : ProtocolValue] = [:]
     
+    public init() {
+    }
+    
     public init(_ examples: [ProtocolValue]) {
         examples.forEach { example in
             try? self.add(example)
         }
     }
     
-    public init(_ typeMap: [String : Decodable.Type]) {
-        self.typeMap = typeMap
+    public init(_ types: [Decodable.Type]) {
+        types.forEach { decodable in
+            self.add(typeOf: decodable)
+        }
     }
     
     /// Insert the given example into the example array, replacing any existing example with the
@@ -128,7 +133,7 @@ open class GenericPolymorphicSerializer<ProtocolValue> : GenericSerializer {
     
     /// Insert the given `ProtocolValue.Type` into the type map, replacing any existing class with
     /// the same "type" decoding.
-    public final func add(typeOf typeValue: Decodable.Type) throws {
+    public final func add(typeOf typeValue: Decodable.Type) {
         let typeName = (typeValue as? PolymorphicStaticTyped.Type)?.typeName ?? "\(typeValue)"
         typeMap[typeName] = typeValue
         _examples[typeName] = nil

--- a/Sources/JsonModel/PolymorphicSerializer.swift
+++ b/Sources/JsonModel/PolymorphicSerializer.swift
@@ -29,7 +29,7 @@ public protocol PolymorphicRepresentable : PolymorphicTyped, Decodable {
 /// serialization protocols defined in Swift 2.0 where an object could conform to either the
 /// `Encodable` protocol or the `Decodable` protocol without conforming to the `Codable`
 /// protocol. Additionally, these older objects often had serialization strategies that
-/// conflicted with either encoding or decoding. To work-around this, we introduced the
+/// conflicted with either encoding or decoding. To work around this, we introduced the
 /// `PolymorphicRepresentable` protocol which **only** required adherence to the `Decodable`
 /// protocol and not to the `Encodable` protocol. This allowed developers who only needed
 /// to decode their objects, to use the ``SerializationFactory`` to handle polymorphic

--- a/Sources/JsonModel/PolymorphicWrapper.swift
+++ b/Sources/JsonModel/PolymorphicWrapper.swift
@@ -12,7 +12,7 @@ import Foundation
 /// limitations, it is **highly recommended** that you thoroughly unit test your implementations
 /// for the expected encoding and decoding of polymorphic objects.
 ///
-/// The simpliest example is a non-null, read/write, required value without a default such as:
+/// The simplest example is a non-null, read/write, required value without a default such as:
 ///
 /// ```
 /// struct SampleTest : Codable {

--- a/Sources/JsonModel/PolymorphicWrapper.swift
+++ b/Sources/JsonModel/PolymorphicWrapper.swift
@@ -69,7 +69,7 @@ import Foundation
 ///
 /// - Limitation 3:
 /// This property wrapper does not explicitly require conformance to the `Codable` or
-/// `PolymorphicTyped` protocols (limitation of Swift Generics as of 03/14/2022), but will fail to
+/// `PolymorphicTyped` protocols (limitation of Swift Generics as of 03/14/2023), but will fail to
 /// encode at runtime if the objects do *not* conform to these protocols. Finally, if you attempt
 /// to decode with a ``SerializationFactory`` that does not have a registered serializer for the
 /// given ``ProtocolValue``, then decoding will fail at runtime.

--- a/Sources/JsonModel/PolymorphicWrapper.swift
+++ b/Sources/JsonModel/PolymorphicWrapper.swift
@@ -1,0 +1,173 @@
+// Created 3/13/23
+// swift-tools-version:5.0
+
+import Foundation
+
+/// An explicitly defined protocol for a polymorphically-typed serializable value.
+public protocol PolymorphicCodable : PolymorphicRepresentable, Encodable {
+}
+
+/// Wrap a ``PolymorphicCodable`` interface to allow automatic synthesis of a polymorphically-typed value.
+///
+/// This implementation was modified from an investigation of property wrappers originally created
+/// by Aaron Rabara in January, 2023. - syoung 03/14/2023
+///
+/// There are several limitations to this implementation which are described below. Because of these
+/// limitations, it is **highly recommended** that you thoroughly unit test your implementations
+/// for the expected encoding and decoding of polymorphic objects.
+///
+/// The simpliest example is a non-null, read/write, required value without a default such as:
+///
+/// ```
+/// struct SampleTest : Codable {
+///     @PolymorphicValue var single: Sample
+/// }
+/// ```
+///
+/// - Limitation 1:
+/// If the property is read-only, it must still be defined with a setter, though the setter can be
+/// private.
+///
+/// ```
+/// struct SampleTest : Codable {
+///     @PolymorphicValue private(set) var single: Sample
+/// }
+/// ```
+///
+/// - Limitation 2:
+/// This property wrapper will only auto-synthesize the `Codable` methods for a non-null value
+/// without a default. Therefore, if you wish to define a default or nullable property, then
+/// you must unwrap in your implementation.
+///
+/// ```
+/// public struct SampleTest : Codable {
+///     private enum CodingKeys : String, CodingKey {
+///         case _nullable = "nullable", _defaultValue = "defaultValue"
+///     }
+///
+///     public var nullable: Sample? {
+///         get {
+///             _nullable?.wrappedValue
+///         }
+///         set {
+///             _nullable = newValue.map { .init(wrappedValue: $0) }
+///         }
+///     }
+///     private let _nullable: PolymorphicValue<Sample>?
+///
+///     public var defaultValue: Sample! {
+///         get {
+///             _defaultValue?.wrappedValue ?? SampleA(value: 0)
+///         }
+///         set {
+///             _defaultValue = newValue.map { .init(wrappedValue: $0) }
+///         }
+///     }
+///     private let _defaultValue: PolymorphicValue<Sample>?
+///
+///     public init(nullable: Sample? = nil) {
+///         self._nullable = nullable.map { .init(wrappedValue: $0) }
+///     }
+/// }
+/// ```
+///
+/// - Limitation 3:
+/// This property wrapper does not explicitly require conformance to the `Codable` or
+/// `PolymorphicTyped` protocols (limitation of Swift Generics as of 03/14/2022), but will fail to
+/// encode at runtime if the objects do *not* conform to these protocols. Finally, if you attempt
+/// to decode with a ``SerializationFactory`` that does not have a registered serializer for the
+/// given ``ProtocolValue``, then decoding will fail at runtime.
+///
+/// ```
+///
+/// // This struct will encode and decode properly.
+/// struct SampleA : Sample, PolymorphicCodable {
+///     public private(set) var type: SampleType = .a
+///     public let value: Int
+/// }
+///
+/// // This struct will fail to encode and decode because it does not match the required
+/// // `Codable` protocols.
+/// struct SampleThatFails : Sample {
+///     public private(set) var type: SampleType = .fails
+///     public let value: String
+/// }
+///
+/// // The decoded object must use a factory to create the JSONDecoder that registers
+/// // the serializer for the matching `ProtocolValue`.
+/// class TestFactory : SerializationFactory {
+///     let sampleSerializer = SampleSerializer()
+///     required init() {
+///         super.init()
+///         self.registerSerializer(sampleSerializer)
+///     }
+/// }
+/// ```
+///
+@propertyWrapper
+public struct PolymorphicValue<ProtocolValue> : Codable {
+    public var wrappedValue: ProtocolValue
+    
+    public init(wrappedValue: ProtocolValue, description: String? = nil) {
+        self.wrappedValue = wrappedValue
+    }
+    
+    public init(from decoder: Decoder) throws {
+        self.wrappedValue = try decoder.serializationFactory.decodePolymorphicObject(ProtocolValue.self, from: decoder)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        try encoder.encodePolymorphic(wrappedValue)
+    }
+}
+
+/// Wrap a ``PolymorphicCodable`` interface to allow automatic synthesis of a polymorphically-typed array.
+///
+/// - Example:
+/// ```
+/// struct SampleTest : Codable {
+///     @PolymorphicValue var array: [Sample]
+/// }
+/// ```
+///
+/// - See Also:
+/// ``PolymorphicValue``. The same limitations on that implementation apply to this one.
+///
+@propertyWrapper
+public struct PolymorphicArray<ProtocolValue> : Codable {
+    public var wrappedValue: [ProtocolValue]
+    
+    public init(wrappedValue: [ProtocolValue], description: String? = nil) {
+        self.wrappedValue = wrappedValue
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.unkeyedContainer()
+        self.wrappedValue = try decoder.serializationFactory.decodePolymorphicArray(ProtocolValue.self, from: container)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try wrappedValue.forEach { obj in
+            let nestedEncoder = container.superEncoder()
+            try nestedEncoder.encodePolymorphic(obj)
+        }
+    }
+}
+
+fileprivate enum PolymorphicCodableTypeKeys: String, CodingKey {
+    case type
+}
+
+extension Encoder {
+    fileprivate func encodePolymorphic(_ obj: Any) throws {
+        guard let encodable = obj as? Encodable else {
+            throw EncodingError.invalidValue(obj,
+                .init(codingPath: self.codingPath, debugDescription: "Object `\(type(of: obj))` does not conform to the `Encodable` protocol"))
+        }
+        let typeName = (obj as? PolymorphicTyped)?.typeName ?? "\(type(of: obj))"
+        var container = self.container(keyedBy: PolymorphicCodableTypeKeys.self)
+        try container.encode(typeName, forKey: .type)
+        try encodable.encode(to: self)
+    }
+}

--- a/Sources/JsonModel/PolymorphicWrapper.swift
+++ b/Sources/JsonModel/PolymorphicWrapper.swift
@@ -113,7 +113,7 @@ public struct PolymorphicValue<ProtocolValue> : Codable {
     }
     
     public func encode(to encoder: Encoder) throws {
-        try encoder.encodePolymorphicAny(wrappedValue)
+        try encoder.encodePolymorphic(wrappedValue)
     }
 }
 
@@ -144,19 +144,7 @@ public struct PolymorphicArray<ProtocolValue> : Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
-        try wrappedValue.forEach { obj in
-            let nestedEncoder = container.superEncoder()
-            try nestedEncoder.encodePolymorphicAny(obj)
-        }
+        try container.encodePolymorphic(wrappedValue)
     }
 }
 
-extension Encoder {
-    fileprivate func encodePolymorphicAny(_ obj: Any) throws {
-        guard let encodable = obj as? Encodable else {
-            throw EncodingError.invalidValue(obj,
-                .init(codingPath: self.codingPath, debugDescription: "Object `\(type(of: obj))` does not conform to the `Encodable` protocol"))
-        }
-        try self.encodePolymorphic(encodable)
-    }
-}

--- a/Sources/ResultModel/AnswerResult.swift
+++ b/Sources/ResultModel/AnswerResult.swift
@@ -131,9 +131,8 @@ public final class AnswerResultObject : SerializableResultData, AnswerResult, Mu
         try container.encode(self.startDateTime, forKey: .startDate)
         try container.encodeIfPresent(self.endDateTime, forKey: .endDate)
         if let info = self.jsonAnswerType {
-            let encodable = try info as? Encodable ?? JsonElement.object(try info.jsonDictionary())
             let nestedEncoder = container.superEncoder(forKey: .jsonAnswerType)
-            try encodable.encode(to: nestedEncoder)
+            try nestedEncoder.encodePolymorphic(info)
         }
         let jsonVal = try self.encodingValue()
         try container.encodeIfPresent(jsonVal, forKey: .jsonValue)

--- a/Sources/ResultModel/AnswerType.swift
+++ b/Sources/ResultModel/AnswerType.swift
@@ -47,7 +47,7 @@ public final class AnswerTypeSerializer : GenericPolymorphicSerializer<AnswerTyp
         URL(string: "\(self.interfaceName).json", relativeTo: kSageJsonSchemaBaseURL)!
     }
     
-    init() {
+    override init() {
         super.init([
             AnswerTypeArray.examples().first!,
             AnswerTypeBoolean.examples().first!,

--- a/Sources/ResultModel/AnswerType.swift
+++ b/Sources/ResultModel/AnswerType.swift
@@ -35,7 +35,7 @@ public protocol AnswerType : PolymorphicTyped, DictionaryRepresentable {
     func encodeAnswer(from value: Any?) throws -> JsonElement
 }
 
-public final class AnswerTypeSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
+public final class AnswerTypeSerializer : GenericPolymorphicSerializer<AnswerType>, DocumentableInterface {
     public var documentDescription: String? {
         """
         `AnswerType` is used to allow carrying additional information about the properties of a
@@ -47,8 +47,8 @@ public final class AnswerTypeSerializer : AbstractPolymorphicSerializer, Polymor
         URL(string: "\(self.interfaceName).json", relativeTo: kSageJsonSchemaBaseURL)!
     }
     
-    override init() {
-        examples = [
+    init() {
+        super.init([
             AnswerTypeArray.examples().first!,
             AnswerTypeBoolean.examples().first!,
             AnswerTypeDateTime.examples().first!,
@@ -59,20 +59,11 @@ public final class AnswerTypeSerializer : AbstractPolymorphicSerializer, Polymor
             AnswerTypeObject.examples().first!,
             AnswerTypeString.examples().first!,
             AnswerTypeTime.examples().first!,
-        ]
+        ])
     }
-    
-    public private(set) var examples: [AnswerType]
     
     public override class func typeDocumentProperty() -> DocumentProperty {
         .init(propertyType: .reference(AnswerTypeType.documentableType()))
-    }
-    
-    public func add(_ example: AnswerType) {
-        if let idx = examples.firstIndex(where: { $0.typeName == example.typeName }) {
-            examples.remove(at: idx)
-        }
-        examples.append(example)
     }
 }
 

--- a/Sources/ResultModel/BranchNodeResult.swift
+++ b/Sources/ResultModel/BranchNodeResult.swift
@@ -159,17 +159,11 @@ open class AbstractBranchNodeResultObject : AbstractResultObject {
         try container.encode(path, forKey: .path)
 
         var nestedContainer = container.nestedUnkeyedContainer(forKey: .stepHistory)
-        for result in stepHistory {
-            let nestedEncoder = nestedContainer.superEncoder()
-            try result.encode(to: nestedEncoder)
-        }
+        try nestedContainer.encodePolymorphic(stepHistory)
 
         if let results = asyncResults {
             var asyncContainer = container.nestedUnkeyedContainer(forKey: .asyncResults)
-            for result in results {
-                let nestedEncoder = asyncContainer.superEncoder()
-                try result.encode(to: nestedEncoder)
-            }
+            try asyncContainer.encodePolymorphic(results)
         }
     }
     

--- a/Sources/ResultModel/CollectionResult.swift
+++ b/Sources/ResultModel/CollectionResult.swift
@@ -76,10 +76,7 @@ open class AbstractCollectionResultObject : AbstractResultObject {
         try super.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
         var nestedContainer = container.nestedUnkeyedContainer(forKey: .children)
-        try children.forEach { result in
-            let nestedEncoder = nestedContainer.superEncoder()
-            try result.encode(to: nestedEncoder)
-        }
+        try nestedContainer.encodePolymorphic(children)
     }
     
     override open class func codingKeys() -> [CodingKey] {

--- a/Sources/ResultModel/ResultDataSerializer.swift
+++ b/Sources/ResultModel/ResultDataSerializer.swift
@@ -85,13 +85,13 @@ public final class ResultDataSerializer : GenericPolymorphicSerializer<ResultDat
     /// Insert the given example into the example array, replacing any existing example with the
     /// same `typeName` as one of the new example.
     public func add(_ example: SerializableResultData) {
-        try? add(example as ResultData)
+        try! add(example as ResultData)
     }
     
     /// Insert the given examples into the example array, replacing any existing examples with the
     /// same `typeName` as one of the new examples.
     public func add(contentsOf newExamples: [SerializableResultData]) {
-        try? add(contentsOf: newExamples as [ResultData])
+        try! add(contentsOf: newExamples as [ResultData])
     }
     
     private enum InterfaceKeys : String, OrderedEnumCodingKey, OpenOrderedCodingKey {

--- a/Sources/ResultModel/ResultDataSerializer.swift
+++ b/Sources/ResultModel/ResultDataSerializer.swift
@@ -54,7 +54,7 @@ extension SerializableResultType : DocumentableStringLiteral {
     }
 }
 
-public final class ResultDataSerializer : IdentifiableInterfaceSerializer, PolymorphicSerializer {
+public final class ResultDataSerializer : GenericPolymorphicSerializer<ResultData>, DocumentableInterface {
     public var documentDescription: String? {
         """
         The interface for any `ResultData` that is serialized using the `Codable` protocol and the
@@ -66,8 +66,8 @@ public final class ResultDataSerializer : IdentifiableInterfaceSerializer, Polym
         URL(string: "\(self.interfaceName).json", relativeTo: kSageJsonSchemaBaseURL)!
     }
     
-    override init() {
-        self.examples = [
+    init() {
+        super.init([
             AnswerResultObject.examples().first!,
             CollectionResultObject.examples().first!,
             ErrorResultObject.examples().first!,
@@ -75,10 +75,8 @@ public final class ResultDataSerializer : IdentifiableInterfaceSerializer, Polym
             ResultObject.examples().first!,
             BranchNodeResultObject.examples().first!,
             AssessmentResultObject(),
-        ]
+        ])
     }
-    
-    public private(set) var examples: [ResultData]
     
     public override class func typeDocumentProperty() -> DocumentProperty {
         .init(propertyType: .reference(SerializableResultType.documentableType()))
@@ -87,20 +85,17 @@ public final class ResultDataSerializer : IdentifiableInterfaceSerializer, Polym
     /// Insert the given example into the example array, replacing any existing example with the
     /// same `typeName` as one of the new example.
     public func add(_ example: SerializableResultData) {
-        examples.removeAll(where: { $0.typeName == example.typeName })
-        examples.append(example)
+        try? add(example as ResultData)
     }
     
     /// Insert the given examples into the example array, replacing any existing examples with the
     /// same `typeName` as one of the new examples.
     public func add(contentsOf newExamples: [SerializableResultData]) {
-        let newNames = newExamples.map { $0.typeName }
-        self.examples.removeAll(where: { newNames.contains($0.typeName) })
-        self.examples.append(contentsOf: newExamples)
+        try? add(contentsOf: newExamples as [ResultData])
     }
     
     private enum InterfaceKeys : String, OrderedEnumCodingKey, OpenOrderedCodingKey {
-        case startDate, endDate
+        case identifier, startDate, endDate
         var relativeIndex: Int { 2 }
     }
     
@@ -114,7 +109,7 @@ public final class ResultDataSerializer : IdentifiableInterfaceSerializer, Polym
         guard let key = codingKey as? InterfaceKeys else {
             return super.isRequired(codingKey)
         }
-        return key == .startDate
+        return key == .startDate || key == .identifier
     }
     
     public override class func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
@@ -122,6 +117,9 @@ public final class ResultDataSerializer : IdentifiableInterfaceSerializer, Polym
             return try super.documentProperty(for: codingKey)
         }
         switch key {
+        case .identifier:
+            return .init(propertyType: .primitive(.string), propertyDescription:
+                            "The identifier for the result.")
         case .startDate:
             return .init(propertyType: .format(.dateTime), propertyDescription:
                             "The start date timestamp for the result.")

--- a/Sources/ResultModel/ResultDataSerializer.swift
+++ b/Sources/ResultModel/ResultDataSerializer.swift
@@ -66,7 +66,7 @@ public final class ResultDataSerializer : GenericPolymorphicSerializer<ResultDat
         URL(string: "\(self.interfaceName).json", relativeTo: kSageJsonSchemaBaseURL)!
     }
     
-    init() {
+    override init() {
         super.init([
             AnswerResultObject.examples().first!,
             CollectionResultObject.examples().first!,

--- a/Tests/JsonModelTests/AnyCodableTests.swift
+++ b/Tests/JsonModelTests/AnyCodableTests.swift
@@ -39,15 +39,15 @@ final class AnyCodableTests: XCTestCase {
             
             // The order of the keys should be the same as the `orderedKeys` and *not*
             // in the order defined either using alphabetical sort or the `input` declaration.
-            let actualOrder: [String.Index] = orderedKeys.map {
+            let mappedOrder: [(index: String.Index, value: String) ] = orderedKeys.map {
                 guard let range = jsonString.range(of: $0) else {
                     XCTFail("Could not find \($0) in the json string")
-                    return jsonString.endIndex
+                    return (jsonString.endIndex, "")
                 }
-                return range.lowerBound
-            }
-            let sortedOrder = actualOrder.sorted()
-            XCTAssertEqual(actualOrder, sortedOrder)
+                return (range.lowerBound, $0)
+            }.sorted(by: { $0.index < $1.index })
+            let actualOrder = mappedOrder.map { $0.value }
+            XCTAssertEqual(orderedKeys, actualOrder)
             
             // Decode from the data and the dictionaries should match.
             let object = try decoder.decode(AnyCodableDictionary.self, from: jsonData)

--- a/Tests/JsonModelTests/DocumentableTests.swift
+++ b/Tests/JsonModelTests/DocumentableTests.swift
@@ -196,7 +196,7 @@ class AnotherTestFactory : SerializationFactory {
     }
 }
 
-class AnotherSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
+class AnotherSerializer : GenericPolymorphicSerializer<Another>, DocumentableInterface {
     var jsonSchema: URL {
         URL(string: "Another.json", relativeTo: kSageJsonSchemaBaseURL)!
     }
@@ -205,10 +205,12 @@ class AnotherSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
         "Another example interface used for unit testing."
     }
     
-    let examples: [Another] = [
-        AnotherA(),
-        AnotherB(),
-    ]
+    init() {
+        super.init([
+            AnotherA(),
+            AnotherB(),
+        ])
+    }
     
     override class func typeDocumentProperty() -> DocumentProperty {
         DocumentProperty(propertyType: .reference(AnotherType.self))

--- a/Tests/JsonModelTests/DocumentableTests.swift
+++ b/Tests/JsonModelTests/DocumentableTests.swift
@@ -205,7 +205,7 @@ class AnotherSerializer : GenericPolymorphicSerializer<Another>, DocumentableInt
         "Another example interface used for unit testing."
     }
     
-    init() {
+    override init() {
         super.init([
             AnotherA(),
             AnotherB(),

--- a/Tests/JsonModelTests/DocumentableTests.swift
+++ b/Tests/JsonModelTests/DocumentableTests.swift
@@ -269,11 +269,7 @@ struct AnotherA : Another, Codable {
         try container.encodeIfPresent(self.sampleItem, forKey: .sampleItem)
         if let samples = self.samples {
             var nestedContainer = container.nestedUnkeyedContainer(forKey: .samples)
-            try samples.forEach {
-                let encodable = $0 as! Encodable
-                let nestedEncoder = nestedContainer.superEncoder()
-                try encodable.encode(to: nestedEncoder)
-            }
+            try nestedContainer.encodePolymorphic(samples)
         }
     }
 }

--- a/Tests/JsonModelTests/GooProcotolExampleTests.swift
+++ b/Tests/JsonModelTests/GooProcotolExampleTests.swift
@@ -91,25 +91,6 @@ public struct MooObject : Codable, PolymorphicTyped, GooProtocol {
     }
 }
 
-/// This object must be wrapped to allow serialization at the root.
-///
-/// - Example:
-/// ```
-///     let factory = GooFactory()
-///     let decoder = factory.createJSONDecoder()
-///     let encoder = factory.createJSONEncoder()
-///
-///     let json = """
-///     {
-///         "type" : "ragu",
-///         "value" : 7,
-///         "goo" : { "type" : "foo", "value" : 2 }
-///     }
-///     """.data(using: .utf8)!
-///
-///     let decodedObject = try decoder.decode(PolymorphicValue<GooProtocol>.self, from: json)
-///     let encodedData = try encoder.encode(decodedObject)
-/// ```
 public struct RaguObject : Codable, PolymorphicStaticTyped, GooProtocol {
     public static let typeName: String = "ragu"
 

--- a/Tests/JsonModelTests/GooProcotolExampleTests.swift
+++ b/Tests/JsonModelTests/GooProcotolExampleTests.swift
@@ -1,0 +1,139 @@
+// Created 3/15/23
+// swift-tools-version:5.0
+
+import XCTest
+@testable import JsonModel
+
+final class GooProcotolExampleTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExampleMoo() throws {
+        let factory = GooFactory()
+        let decoder = factory.createJSONDecoder()
+        let encoder = factory.createJSONEncoder()
+        
+        let json = """
+        {
+            "type" : "moo",
+            "goos" : [
+                { "type" : "foo", "value" : 2 },
+                { "type" : "moo", "goos" : [{ "type" : "foo", "value" : 5 }] }
+            ]
+        }
+        """.data(using: .utf8)!
+        
+        let decodedObject = try decoder.decode(MooObject.self, from: json)
+        let encodedData = try encoder.encode(decodedObject)
+        
+        let expectedDictionary = try JSONSerialization.jsonObject(with: json) as! NSDictionary
+        let actualDictionary = try JSONSerialization.jsonObject(with: encodedData) as! NSDictionary
+        XCTAssertEqual(expectedDictionary, actualDictionary)
+    }
+    
+    func testExampleRagu() throws {
+        let factory = GooFactory()
+        let decoder = factory.createJSONDecoder()
+        let encoder = factory.createJSONEncoder()
+        
+        let json = """
+        {
+            "type" : "ragu",
+            "value" : 7,
+            "goo" : { "type" : "foo", "value" : 2 }
+        }
+        """.data(using: .utf8)!
+        
+        let decodedObject = try decoder.decode(PolymorphicValue<GooProtocol>.self, from: json)
+        let encodedData = try encoder.encode(decodedObject)
+        
+        let expectedDictionary = try JSONSerialization.jsonObject(with: json) as! NSDictionary
+        let actualDictionary = try JSONSerialization.jsonObject(with: encodedData) as! NSDictionary
+        XCTAssertEqual(expectedDictionary, actualDictionary)
+    }
+}
+
+public protocol GooProtocol {
+    var value: Int { get }
+}
+
+public struct FooObject : Codable, PolymorphicStaticTyped, GooProtocol {
+    public static let typeName: String = "foo"
+
+    public let value: Int
+
+    public init(value: Int = 0) {
+        self.value = value
+    }
+}
+
+/// This object can be serialized directly.
+public struct MooObject : Codable, PolymorphicTyped, GooProtocol {
+    private enum CodingKeys : String, CodingKey {
+        case typeName = "type", goos
+    }
+    public private(set) var typeName: String = "moo"
+    
+    public var value: Int {
+        goos.count
+    }
+
+    @PolymorphicArray public var goos: [GooProtocol]
+
+    public init(goos: [GooProtocol] = []) {
+        self.goos = goos
+    }
+}
+
+/// This object must be wrapped to allow serialization at the root.
+///
+/// - Example:
+/// ```
+///     let factory = GooFactory()
+///     let decoder = factory.createJSONDecoder()
+///     let encoder = factory.createJSONEncoder()
+///
+///     let json = """
+///     {
+///         "type" : "ragu",
+///         "value" : 7,
+///         "goo" : { "type" : "foo", "value" : 2 }
+///     }
+///     """.data(using: .utf8)!
+///
+///     let decodedObject = try decoder.decode(PolymorphicValue<GooProtocol>.self, from: json)
+///     let encodedData = try encoder.encode(decodedObject)
+/// ```
+public struct RaguObject : Codable, PolymorphicStaticTyped, GooProtocol {
+    public static let typeName: String = "ragu"
+
+    public let value: Int
+    @PolymorphicValue public private(set) var goo: GooProtocol
+
+    public init(value: Int, goo: GooProtocol) {
+        self.value = value
+        self.goo = goo
+    }
+}
+
+open class GooFactory : SerializationFactory {
+    
+    public let gooSerializer = GenericPolymorphicSerializer<GooProtocol>([
+        MooObject(),
+        FooObject(),
+    ])
+    
+    public required init() {
+        super.init()
+        
+        self.registerSerializer(gooSerializer)
+        gooSerializer.add(typeOf: RaguObject.self)
+    }
+}
+

--- a/Tests/JsonModelTests/PolymorphicSerializerTests.swift
+++ b/Tests/JsonModelTests/PolymorphicSerializerTests.swift
@@ -61,7 +61,7 @@ final class PolymorphicSerializerTests: XCTestCase {
             XCTAssertEqual("a", typeName)
         }
         else {
-            XCTFail("Encoding does not include 'valtypeue' keyword. \(dictionary)")
+            XCTFail("Encoding does not include 'type' keyword. \(dictionary)")
         }
     }
     

--- a/Tests/JsonModelTests/PolymorphicSerializerTests.swift
+++ b/Tests/JsonModelTests/PolymorphicSerializerTests.swift
@@ -134,7 +134,6 @@ struct SampleWrapper : Codable {
 }
 
 class SampleSerializer : GenericPolymorphicSerializer<Sample>, DocumentableInterface {
-    //AbstractPolymorphicSerializer, PolymorphicSerializer {
     var jsonSchema: URL {
         URL(string: "Sample.json", relativeTo: kSageJsonSchemaBaseURL)!
     }

--- a/Tests/JsonModelTests/PolymorphicSerializerTests.swift
+++ b/Tests/JsonModelTests/PolymorphicSerializerTests.swift
@@ -101,7 +101,7 @@ final class PolymorphicSerializerTests: XCTestCase {
         """.data(using: .utf8)! // our data in native (JSON) format
         
         let factory = TestFactory.defaultFactory
-        try factory.sampleSerializer.add(typeOf: SampleC.self)
+        factory.sampleSerializer.add(typeOf: SampleC.self)
         let decoder = factory.createJSONDecoder()
         
         let sampleWrapper = try decoder.decode(SampleWrapper.self, from: json)
@@ -143,7 +143,7 @@ class SampleSerializer : GenericPolymorphicSerializer<Sample>, DocumentableInter
         "Sample is an example interface used for unit testing."
     }
     
-    init() {
+    override init() {
         super.init([
             SampleA(value: 3),
             SampleB(value: "foo"),

--- a/Tests/JsonModelTests/PolymorphicSerializerTests.swift
+++ b/Tests/JsonModelTests/PolymorphicSerializerTests.swift
@@ -7,10 +7,16 @@ import XCTest
 
 final class PolymorphicSerializerTests: XCTestCase {
     
-    func testSampleSerializer() {
+    func testSampleSerializer() throws {
         let serializer = SampleSerializer()
         
         XCTAssertEqual("Sample", serializer.interfaceName)
+        
+        try serializer.validate()
+        
+    }
+    
+    func testSampleSerializer_Decoding() throws {
         
         let json = """
         {
@@ -21,41 +27,41 @@ final class PolymorphicSerializerTests: XCTestCase {
         
         let factory = TestFactory.defaultFactory
         let decoder = factory.createJSONDecoder()
+        
+        let sampleWrapper = try decoder.decode(SampleWrapper.self, from: json)
+        
+        guard let sample = sampleWrapper.value as? SampleA else {
+            XCTFail("\(sampleWrapper.value) not of expected type.")
+            return
+        }
+        
+        XCTAssertEqual(5, sample.value)
+    }
+    
+    func testSampleSerializer_Encoding() throws {
+        let sampleWrapper = SampleWrapper(value: SampleA(value: 5))
+        let factory = TestFactory.defaultFactory
         let encoder = factory.createJSONEncoder()
         
-        do {
-            let sampleWrapper = try decoder.decode(SampleWrapper.self, from: json)
-            
-            guard let sample = sampleWrapper.value as? SampleA else {
-                XCTFail("\(sampleWrapper.value) not of expected type.")
-                return
-            }
-            
-            XCTAssertEqual(5, sample.value)
-            
-            let encoding = try encoder.encode(sampleWrapper)
-            let encodedJson = try JSONSerialization.jsonObject(with: encoding, options: [])
-            guard let dictionary = encodedJson as? [String : Any] else {
-                XCTFail("\(encodedJson) not a dictionary.")
-                return
-            }
-            
-            if let value = dictionary["value"] as? Int {
-                XCTAssertEqual(5, value)
-            }
-            else {
-                XCTFail("Encoding does not include 'value' keyword. \(dictionary)")
-            }
-            
-            if let typeName = dictionary["type"] as? String {
-                XCTAssertEqual("a", typeName)
-            }
-            else {
-                XCTFail("Encoding does not include 'valtypeue' keyword. \(dictionary)")
-            }
-
-        } catch let err {
-            XCTFail("Failed to decode/encode object: \(err)")
+        let encoding = try encoder.encode(sampleWrapper)
+        let encodedJson = try JSONSerialization.jsonObject(with: encoding, options: [])
+        guard let dictionary = encodedJson as? [String : Any] else {
+            XCTFail("\(encodedJson) not a dictionary.")
+            return
+        }
+        
+        if let value = dictionary["value"] as? Int {
+            XCTAssertEqual(5, value)
+        }
+        else {
+            XCTFail("Encoding does not include 'value' keyword. \(dictionary)")
+        }
+        
+        if let typeName = dictionary["type"] as? String {
+            XCTAssertEqual("a", typeName)
+        }
+        else {
+            XCTFail("Encoding does not include 'valtypeue' keyword. \(dictionary)")
         }
     }
     
@@ -84,10 +90,37 @@ final class PolymorphicSerializerTests: XCTestCase {
             XCTFail("Failed to decode/encode object: \(err)")
         }
     }
+    
+    func testSampleSerializer_StaticTyped() throws {
+        let json = """
+        {
+            "name": "moo",
+            "type": "c",
+            "value": 2
+        }
+        """.data(using: .utf8)! // our data in native (JSON) format
+        
+        let factory = TestFactory.defaultFactory
+        try factory.sampleSerializer.add(typeOf: SampleC.self)
+        let decoder = factory.createJSONDecoder()
+        
+        let sampleWrapper = try decoder.decode(SampleWrapper.self, from: json)
+            
+        guard let sample = sampleWrapper.value as? SampleC else {
+            XCTFail("\(sampleWrapper.value) not of expected type.")
+            return
+        }
+        
+        XCTAssertEqual("moo", sample.name)
+        XCTAssertEqual(2, sample.value)
+    }
 }
 
 struct SampleWrapper : Codable {
     let value: Sample
+    init(value: Sample) {
+        self.value = value
+    }
     init(from decoder: Decoder) throws {
         self.value = try decoder.serializationFactory.decodePolymorphicObject(Sample.self, from: decoder)
     }
@@ -100,7 +133,8 @@ struct SampleWrapper : Codable {
     }
 }
 
-class SampleSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
+class SampleSerializer : GenericPolymorphicSerializer<Sample>, DocumentableInterface {
+    //AbstractPolymorphicSerializer, PolymorphicSerializer {
     var jsonSchema: URL {
         URL(string: "Sample.json", relativeTo: kSageJsonSchemaBaseURL)!
     }
@@ -109,10 +143,12 @@ class SampleSerializer : AbstractPolymorphicSerializer, PolymorphicSerializer {
         "Sample is an example interface used for unit testing."
     }
     
-    let examples: [Sample] = [
-        SampleA(value: 3),
-        SampleB(value: "foo"),
-    ]
+    init() {
+        super.init([
+            SampleA(value: 3),
+            SampleB(value: "foo"),
+        ])
+    }
     
     override class func typeDocumentProperty() -> DocumentProperty {
         DocumentProperty(propertyType: .reference(SampleType.self))
@@ -340,6 +376,13 @@ extension SampleB : DocumentableStruct {
         return [SampleB(value: "foo"),
                 SampleB(value: "foo", animals: SampleAnimals.birds, jsonBlob: .array([1,2]), timestamp: Date(), numberMap: ["one" : 1])]
     }
+}
+
+struct SampleC : Sample, Codable, PolymorphicStaticTyped {
+    static var typeName: String { "c" }
+    
+    let name: String
+    let value: UInt
 }
 
 struct SampleNotRegistered : Sample, Codable {

--- a/Tests/JsonModelTests/PolymorphicWrapperTests.swift
+++ b/Tests/JsonModelTests/PolymorphicWrapperTests.swift
@@ -1,0 +1,67 @@
+// Created 3/13/23
+// swift-tools-version:5.0
+
+import XCTest
+@testable import JsonModel
+
+final class PolymorphicWrapperTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testPolymorphicPropertyWrappers() throws {
+        let json = """
+        {
+            "single" : { "type" : "a", "value" : 1 },
+            "array" : [
+                { "type" : "a", "value" : 10 },
+                { "type" : "a", "value" : 11 },
+                { "type" : "b", "value" : "foo" }
+            ]
+        }
+        """.data(using: .utf8)!
+        
+        let factory = TestFactory.defaultFactory
+        let decoder = factory.createJSONDecoder()
+        let encoder = factory.createJSONEncoder()
+        
+        let decodedObject = try decoder.decode(SampleTest.self, from: json)
+        
+        XCTAssertEqual(SampleA(value: 1), decodedObject.single as? SampleA)
+        XCTAssertEqual(3, decodedObject.array.count)
+        XCTAssertEqual(SampleA(value: 10), decodedObject.array.first as? SampleA)
+        XCTAssertEqual(SampleB(value: "foo"), decodedObject.array.last as? SampleB)
+        XCTAssertNil(decodedObject.nullable)
+        
+        let encodedData = try encoder.encode(decodedObject)
+        let encodedJson = try JSONDecoder().decode(JsonElement.self, from: encodedData)
+        let expectedJson = try JSONDecoder().decode(JsonElement.self, from: json)
+        
+        XCTAssertEqual(expectedJson, encodedJson)
+    }
+}
+
+fileprivate struct SampleTest : Codable {
+    private enum CodingKeys : String, CodingKey {
+        case single, array, _nullable = "nullable"
+    }
+    
+    @PolymorphicValue private(set) var single: Sample
+    @PolymorphicArray var array: [Sample]
+    
+    public var nullable: Sample? {
+        _nullable?.wrappedValue
+    }
+    private let _nullable: PolymorphicValue<Sample>?
+    
+    init(single: Sample, array: [Sample], nullable: Sample? = nil) {
+        self.single = single
+        self.array = array
+        self._nullable = nullable.map { PolymorphicValue(wrappedValue: $0) }
+    }
+}

--- a/Tests/JsonModelTests/PolymorphicWrapperTests.swift
+++ b/Tests/JsonModelTests/PolymorphicWrapperTests.swift
@@ -44,6 +44,44 @@ final class PolymorphicWrapperTests: XCTestCase {
         
         XCTAssertEqual(expectedJson, encodedJson)
     }
+    
+    func testPolymorphicPropertyWrapper_DefaultTyped() throws {
+        let sampleTest = SampleTest(single: SampleX(name: "foo", value: 5), array: [])
+        let encoder = JSONEncoder()
+        let jsonData = try encoder.encode(sampleTest)
+        let dictionary = try JSONSerialization.jsonObject(with: jsonData) as! NSDictionary
+        let expectedDictionary : NSDictionary = [
+            "single" : [
+                "type" : "SampleX",
+                "name" : "foo",
+                "value" : 5
+            ],
+            "array" : []
+        ]
+        XCTAssertEqual(expectedDictionary, dictionary)
+    }
+    
+    func testPolymorphicPropertyWrapper_NotDictionary() throws {
+        let sampleTest = SampleTest(single: "foo", array: [])
+        let encoder = JSONEncoder()
+        do {
+            let _ = try encoder.encode(sampleTest)
+        }
+        catch EncodingError.invalidValue(_, let context) {
+            XCTAssertEqual("Cannot encode a polymorphic object to a single value container.", context.debugDescription)
+            return
+        }
+        
+        XCTFail("This test should throw an invalid value error and exit before here.")
+    }
+}
+
+extension String : Sample {
+}
+
+fileprivate struct SampleX : Sample, Encodable {
+    let name: String
+    let value: UInt
 }
 
 fileprivate struct SampleTest : Codable {


### PR DESCRIPTION
Cleaned up the code from the investigation by @rabaraaaron before we forget what we did. :)

Note: Until MTB updates their code to JsonModel 2.0, we can't actually use any of this or migrate `AssessmentModel` serialization to use it. Since that could take a while, I didn't want to us to forget about them.

@kalperin