### PR TITLE
While testing out assorted validators, found a peanut

### DIFF
--- a/Sources/JsonModel/JsonSchema.swift
+++ b/Sources/JsonModel/JsonSchema.swift
@@ -418,7 +418,7 @@ public struct JsonSchemaArray : Codable, Hashable {
 }
 
 public enum JsonSchemaFormat : String, Codable, Hashable {
-    case dateTime = "date-time", date, time, uuid, uri, uriRelative = "uri-relative", email
+    case dateTime = "date-time", date, time, uuid, uri, uriRelative = "uri-reference", email
 }
 
 public struct JsonSchemaPrimitive : Codable, Hashable {


### PR DESCRIPTION
https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3.5

This was failing validation b/c I had it as "uri-relative" rather than "uri-reference" - Oops.