### PR TITLE
Draft 7 does not support definining both “$ref” and “const

### DIFF
--- a/Sources/JsonModel/JsonSchema.swift
+++ b/Sources/JsonModel/JsonSchema.swift
@@ -559,19 +559,19 @@ public struct JsonSchemaStringEnum : Codable, Hashable {
 
 public struct JsonSchemaConst : Codable, Hashable {
     private enum CodingKeys : String, OrderedEnumCodingKey {
-        case const, _ref = "$ref", description
+        case const, description
     }
     public let const: String
-    public var ref: JsonSchemaReferenceId? { _ref?.value}
-    private let _ref: JsonSchemaRef?
     public let description: String?
-
+    
     public init(const: String,
                 ref: JsonSchemaReferenceId? = nil,
                 description: String? = nil) {
         self.const = const
-        self._ref = ref.map { .init($0) }
         self.description = description
+        
+        // TODO: syoung 06/06/2023 Draft 7 does not support $ref and const together - revisit when we update the target schema
+        // self.ref = ref
     }
 }
 

--- a/Sources/ResultModel/FileResult.swift
+++ b/Sources/ResultModel/FileResult.swift
@@ -113,7 +113,7 @@ extension FileResultObject : DocumentableStruct {
         case .startDateTime, .endDateTime:
             return .init(propertyType: .format(.dateTime))
         case .relativePath:
-            return .init(propertyType: .primitive(.string), propertyDescription:
+            return .init(propertyType: .format(.uriRelative), propertyDescription:
                             "The relative path to the file-based result.")
         case .contentType:
             return .init(propertyType: .primitive(.string), propertyDescription:

--- a/Tests/JsonModelTests/JsonSchemaTests.swift
+++ b/Tests/JsonModelTests/JsonSchemaTests.swift
@@ -286,7 +286,6 @@ final class JsonSchemaTests: XCTestCase {
     func testJsonSchemaConst() {
         let json = """
         {
-            "$ref": "#/definitions/FooType",
             "const": "boo"
         }
         """.data(using: .utf8)! // our data in native (JSON) format
@@ -411,7 +410,6 @@ final class JsonSchemaTests: XCTestCase {
             "description": "This is an example of a polymorphic object",
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/GooType",
                     "const": "foo"
                 },
                 "identifier": {
@@ -544,7 +542,6 @@ final class JsonSchemaTests: XCTestCase {
             },
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/GooType",
                     "const": "foo"
                 },
                 "identifier": {
@@ -711,7 +708,6 @@ final class JsonSchemaTests: XCTestCase {
                 "description": "This is an example of a polymorphic object",
                 "properties": {
                     "type": {
-                        "$ref": "#/definitions/GooType",
                         "const": "foo"
                     },
                     "identifier": {

--- a/Tests/ResultModelTests/DocumentableTests.swift
+++ b/Tests/ResultModelTests/DocumentableTests.swift
@@ -73,7 +73,8 @@ final class DocumentableTests: XCTestCase {
                let typeProp = props["type"],
                case .const(let constType) = typeProp {
                 XCTAssertEqual("test", constType.const)
-                XCTAssertEqual("https://sage-bionetworks.github.io/mobile-client-json/schemas/v2/ResultData.json#SerializableResultType", constType.ref?.classPath)
+                // TODO: syoung 06/06/2023 Revisit this when/if we update the schema from Draft 7 to a new schema that supports both const and $ref
+//                XCTAssertEqual("https://sage-bionetworks.github.io/mobile-client-json/schemas/v2/ResultData.json#SerializableResultType", constType.ref?.classPath)
             }
             else {
                 XCTFail("Failed to add expected property.")


### PR DESCRIPTION
Due to the nature of standards that were still in development when we started using them, Json Schema Draft 7 does not specifically allow using “$ref” and “const” as keys in the same object so using them together is indeterminant. Depending upon the validator, some ignore "$ref", others ignore "const", and still others throw an error.

This change removes the "$ref" from all properties defined as "const".

https://github.com/Sage-Bionetworks/mobile-client-json/pull/13